### PR TITLE
fix: "Tools" preferences' toggles not showing correct initial state

### DIFF
--- a/app/assets/javascripts/preferences/panes/general-segments/Tools.tsx
+++ b/app/assets/javascripts/preferences/panes/general-segments/Tools.tsx
@@ -26,7 +26,7 @@ export const Tools: FunctionalComponent<Props> = observer(
       application.getPreference(PrefKey.EditorResizersEnabled, true)
     );
     const [spellcheck, setSpellcheck] = useState(() =>
-      application.getPreference(PrefKey.EditorSpellcheck, false)
+      application.getPreference(PrefKey.EditorSpellcheck, true)
     );
 
     const toggleMonospaceFont = () => {


### PR DESCRIPTION
This PR fixes the issues of the toggles in the Tools prefs section not showing the correct inital state on new sessions by adding a default value to the getPreference calls.