### PR TITLE
fix(web): file protected overlay not toggling off correctly

### DIFF
--- a/packages/web/src/javascripts/Components/FileView/FileView.tsx
+++ b/packages/web/src/javascripts/Components/FileView/FileView.tsx
@@ -13,9 +13,17 @@ const FileView = ({ application, viewControllerManager, file }: FileViewProps) =
     setShouldShowProtectedOverlay(viewControllerManager.filesController.showProtectedOverlay)
   }, [viewControllerManager.filesController.showProtectedOverlay])
 
-  const dismissProtectedWarning = useCallback(() => {
-    void viewControllerManager.filesController.toggleFileProtection(file)
-  }, [file, viewControllerManager.filesController])
+  const dismissProtectedOverlay = useCallback(async () => {
+    let showFileContents = true
+
+    if (application.hasProtectionSources()) {
+      showFileContents = await application.protections.authorizeItemAccess(file)
+    }
+
+    if (showFileContents) {
+      setShouldShowProtectedOverlay(false)
+    }
+  }, [application, file])
 
   return shouldShowProtectedOverlay ? (
     <div aria-label="Note" className="section editor sn-component">
@@ -23,7 +31,7 @@ const FileView = ({ application, viewControllerManager, file }: FileViewProps) =
         <ProtectedItemOverlay
           viewControllerManager={viewControllerManager}
           hasProtectionSources={application.hasProtectionSources()}
-          onViewItem={dismissProtectedWarning}
+          onViewItem={dismissProtectedOverlay}
           itemType={'note'}
         />
       </div>

--- a/packages/web/src/javascripts/Components/FileView/FileView.tsx
+++ b/packages/web/src/javascripts/Components/FileView/FileView.tsx
@@ -5,9 +5,11 @@ import FileViewWithoutProtection from './FileViewWithoutProtection'
 import { FileViewProps } from './FileViewProps'
 
 const FileView = ({ application, viewControllerManager, file }: FileViewProps) => {
-  const [shouldShowProtectedOverlay, setShouldShowProtectedOverlay] = useState(
-    file.protected && !application.hasProtectionSources(),
-  )
+  const [shouldShowProtectedOverlay, setShouldShowProtectedOverlay] = useState(false)
+
+  useEffect(() => {
+    viewControllerManager.filesController.setShowProtectedOverlay(file.protected && !application.hasProtectionSources())
+  }, [application, file.protected, viewControllerManager.filesController])
 
   useEffect(() => {
     setShouldShowProtectedOverlay(viewControllerManager.filesController.showProtectedOverlay)

--- a/packages/web/src/javascripts/Controllers/FilesController.ts
+++ b/packages/web/src/javascripts/Controllers/FilesController.ts
@@ -423,6 +423,7 @@ export class FilesController extends AbstractViewController {
         this.setShowProtectedOverlay(false)
       }
     }
+    void this.application.sync.sync()
   }
 
   downloadFiles = async (files: FileItem[]) => {


### PR DESCRIPTION
Fixes an issue where once toggled, the protected overlay stay on even for files which were not protected.