### PR TITLE
fix(web): prevent jumping the page contents on mobile when editing notes offline

### DIFF
--- a/packages/web/src/stylesheets/_editor.scss
+++ b/packages/web/src/stylesheets/_editor.scss
@@ -56,6 +56,7 @@ $heading-height: 75px;
       &:disabled {
         color: var(--editor-title-input-color);
       }
+
       &:focus {
         box-shadow: none;
       }
@@ -65,9 +66,12 @@ $heading-height: 75px;
   #save-status-container {
     position: relative;
     min-width: 16ch;
-    max-width: 16ch;
     overflow: visible;
     margin-right: 20px;
+
+    @media screen and (min-width: 768px) {
+      max-width: 16ch;
+    }
   }
 
   #save-status {


### PR DESCRIPTION
[Internal link](https://app.asana.com/0/1200588672119490/1202584553037937)