### PR TITLE
fix: popover header getting hidden on desktop by titlebar

### DIFF
--- a/packages/desktop/app/javascripts/Renderer/Renderer.ts
+++ b/packages/desktop/app/javascripts/Renderer/Renderer.ts
@@ -123,6 +123,10 @@ async function configureWindow(remoteBridge: CrossProcessBridge) {
     the app content height so its not overflowing */
     sheet.insertRule('body { padding-top: var(--sn-desktop-titlebar-height); }', sheet.cssRules.length)
     sheet.insertRule(
+      '[data-popover] { padding-top: calc(var(--sn-desktop-titlebar-height) + 0.5rem); }',
+      sheet.cssRules.length,
+    )
+    sheet.insertRule(
       `.main-ui-view { height: calc(100vh - var(--sn-desktop-titlebar-height)) !important;
         min-height: calc(100vh - var(--sn-desktop-titlebar-height)) !important; }`,
       sheet.cssRules.length,


### PR DESCRIPTION
Fixes the issue where on small window size, the popover header on the desktop app got hidden by the titlebar, which makes closing the popover not possible.