### PR TITLE
fix: viewport height on mobile Chrome & Safari

### DIFF
--- a/packages/web/src/javascripts/App.tsx
+++ b/packages/web/src/javascripts/App.tsx
@@ -39,6 +39,10 @@ const getKey = () => {
 
 const RootId = 'app-group-root'
 
+const setViewportHeight = () => {
+  document.documentElement.style.setProperty('--viewport-height', `${window.innerHeight}px`)
+}
+
 const startApplication: StartApplication = async function startApplication(
   defaultSyncServerHost: string,
   device: WebOrDesktopDevice,
@@ -54,6 +58,8 @@ const startApplication: StartApplication = async function startApplication(
     const rootElement = document.getElementById(RootId) as HTMLElement
     root.unmount()
     rootElement.remove()
+    window.removeEventListener('resize', setViewportHeight)
+    window.removeEventListener('orientationchange', setViewportHeight)
     renderApp()
   }
 
@@ -62,6 +68,10 @@ const startApplication: StartApplication = async function startApplication(
     rootElement.id = RootId
     const appendedRootNode = document.body.appendChild(rootElement)
     root = createRoot(appendedRootNode)
+
+    setViewportHeight()
+    window.addEventListener('resize', setViewportHeight)
+    window.addEventListener('orientationchange', setViewportHeight)
 
     root.render(
       <ApplicationGroupView

--- a/packages/web/src/stylesheets/_main.scss
+++ b/packages/web/src/stylesheets/_main.scss
@@ -108,8 +108,12 @@ p {
 }
 
 .main-ui-view {
+  // Fallbacks
   min-height: 100vh;
   height: 100vh;
+  // Mobile-corrected viewport height
+  min-height: var(--viewport-height);
+  height: var(--viewport-height);
   position: relative;
   overflow: auto;
   background-color: var(--editor-header-bar-background-color);


### PR DESCRIPTION
On mobile, Chrome & Safari don't report the "correct" value for `vh` units, so `100vh` ends up being more than what it should be. This PR fixes it by adding an event listener for resize and orientationchange and sets the correct viewport height using CSS variables.

Discussed more here:
[Internal link](https://app.asana.com/0/1202707201988678/1202712080821937/f)