### PR TITLE
fix(docs): Change order of sed commands

### DIFF
--- a/packages/docs/docs/self-hosting/docker.md
+++ b/packages/docs/docs/self-hosting/docker.md
@@ -166,10 +166,10 @@ Due to mounted volumes, we recommend running the setup as a root user. If you wi
 
     ```shell
     sed -i "s/auth_jwt_secret/$(openssl rand -hex 32)/g" .env
-    sed -i "s/secret/$(openssl rand -hex 32)/g" docker/auth.env
     sed -i "s/legacy_jwt_secret/$(openssl rand -hex 32)/g" docker/auth.env
     sed -i "s/secret_key/$(openssl rand -hex 32)/g" docker/auth.env
     sed -i "s/server_key/$(openssl rand -hex 32)/g" docker/auth.env
+    sed -i "s/secret/$(openssl rand -hex 32)/g" docker/auth.env
     ```
 
     **Note:** If you are running `sed` on macOS or BSD, change instances of `sed -i` to `sed -i ''`.


### PR DESCRIPTION
As it was before, the value "secret" in "secret_key" and "jegacy_jwt_secret" would be replaced by the key generated for "secret". This reduced the security of the keys as all three keys would be almost the same. By moving the command for secret to the bottom, this problem no longer occurs.