### PR TITLE
fix: info button and version nr for extensions

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -162,7 +162,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/standardnotes/docs/edit/main/',
+          editUrl: 'https://github.com/standardnotes/app/blob/main/packages/docs/',
           routeBasePath: '/',
           remarkPlugins: [math],
           rehypePlugins: [katex],

--- a/packages/features/src/Domain/Feature/FeatureDescription.ts
+++ b/packages/features/src/Domain/Feature/FeatureDescription.ts
@@ -34,6 +34,7 @@ export type BaseFeatureDescription = RoleFields & {
   no_mobile?: boolean
   thumbnail_url?: string
   permission_name: PermissionName
+  version?: string
 }
 
 export type ServerFeatureDescription = RoleFields & {

--- a/packages/web/src/javascripts/Components/Preferences/Panes/General/Advanced/Packages/PackageEntry.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/General/Advanced/Packages/PackageEntry.tsx
@@ -64,18 +64,28 @@ const PackageEntry: FunctionComponent<PackageEntryProps> = ({ application, exten
 
   const isThirdParty = 'identifier' in extension && application.features.isThirdPartyFeature(extension.identifier)
 
+  const thirdPartyPackageInfo = isThirdParty? extension.thirdPartyPackageInfo: undefined;
+
+  const showThirdPartyMarketingInfo = () => {
+    window.open(thirdPartyPackageInfo?.marketing_url, '_blank')?.focus()
+  }
+
   return (
     <PreferencesSegment classes={'mb-5'}>
-      <PackageEntrySubInfo isThirdParty={isThirdParty} extensionName={extensionName} changeName={changeExtensionName} />
+      <PackageEntrySubInfo isThirdParty={isThirdParty} extensionName={extensionName} featureDescription={thirdPartyPackageInfo} changeName={changeExtensionName} />
 
       <div className="my-1" />
 
-      {isThirdParty && (
-        <div>Version: {extension.thirdPartyPackageInfo.version}</div>
-      )}
-
       {isThirdParty && localInstallable && (
         <UseHosted offlineOnly={offlineOnly} toggleOfflineOnly={toggleOfflineOnly} />
+      )}
+
+      {isThirdParty && thirdPartyPackageInfo && (
+        <div className="mt-2 flex flex-row">
+          <Button small className="cursor-pointer" onClick={showThirdPartyMarketingInfo}>
+            Info
+          </Button>  
+        </div>
       )}
 
       <div className="mt-2 flex flex-row">

--- a/packages/web/src/javascripts/Components/Preferences/Panes/General/Advanced/Packages/PackageEntry.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/General/Advanced/Packages/PackageEntry.tsx
@@ -70,6 +70,10 @@ const PackageEntry: FunctionComponent<PackageEntryProps> = ({ application, exten
 
       <div className="my-1" />
 
+      {isThirdParty && (
+        <div>Version: {extension.thirdPartyPackageInfo.version}</div>
+      )}
+
       {isThirdParty && localInstallable && (
         <UseHosted offlineOnly={offlineOnly} toggleOfflineOnly={toggleOfflineOnly} />
       )}

--- a/packages/web/src/javascripts/Components/Preferences/Panes/General/Advanced/Packages/PackageEntrySubInfo.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/General/Advanced/Packages/PackageEntrySubInfo.tsx
@@ -1,13 +1,15 @@
 import Button from '@/Components/Button/Button'
+import { ThirdPartyFeatureDescription } from '@standardnotes/features'
 import { FunctionComponent, useState, useRef, useEffect } from 'react'
 
 type Props = {
   extensionName: string
   changeName: (newName: string) => void
   isThirdParty: boolean
+  featureDescription: ThirdPartyFeatureDescription | undefined
 }
 
-const PackageEntrySubInfo: FunctionComponent<Props> = ({ extensionName, changeName, isThirdParty }) => {
+const PackageEntrySubInfo: FunctionComponent<Props> = ({ extensionName, changeName, isThirdParty, featureDescription }) => {
   const [isRenaming, setIsRenaming] = useState(false)
   const [newExtensionName, setNewExtensionName] = useState<string>(extensionName)
 
@@ -40,32 +42,40 @@ const PackageEntrySubInfo: FunctionComponent<Props> = ({ extensionName, changeNa
   }
 
   return (
-    <div className="flex flex-row flex-wrap items-center gap-3">
-      <input
-        ref={inputRef}
-        disabled={!isRenaming || !renameable}
-        autoComplete="off"
-        className="no-border flex-grow bg-default px-0 text-base font-bold text-text"
-        type="text"
-        value={newExtensionName}
-        onChange={({ target: input }) => setNewExtensionName((input as HTMLInputElement)?.value)}
-      />
+    <div>
+      <div className="flex flex-row flex-wrap items-center gap-3">
+        <input
+          ref={inputRef}
+          disabled={!isRenaming || !renameable}
+          autoComplete="off"
+          className="no-border flex-grow bg-default px-0 text-base font-bold text-text"
+          type="text"
+          value={newExtensionName}
+          onChange={({ target: input }) => setNewExtensionName((input as HTMLInputElement)?.value)}
+        />
 
-      {isRenaming && (
-        <>
-          <Button small className="cursor-pointer" onClick={confirmRename}>
-            Confirm
-          </Button>
-          <Button small className="cursor-pointer" onClick={cancelRename}>
-            Cancel
-          </Button>
-        </>
-      )}
+        {isRenaming && (
+          <>
+            <Button small className="cursor-pointer" onClick={confirmRename}>
+              Confirm
+            </Button>
+            <Button small className="cursor-pointer" onClick={cancelRename}>
+              Cancel
+            </Button>
+          </>
+        )}
 
-      {renameable && !isRenaming && (
-        <Button small className="cursor-pointer" onClick={startRenaming}>
-          Rename
-        </Button>
+        {renameable && !isRenaming && (
+          <Button small className="cursor-pointer" onClick={startRenaming}>
+            Rename
+          </Button>
+        )}
+      </div>
+
+      {isThirdParty && featureDescription && (
+        <div className="flex flex-row flex-wrap items-center gap-3">
+          <div className="flex-grow bg-default px-0 text-base text-text">Version: {featureDescription?.version}</div>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
Hi, 

the docs at https://docs.standardnotes.com/extensions/publishing state the info button (marketing_url), which was not implemented. This commit implements it and also includes the current installed version number for third party extensions.

Best
Anton