### PR TITLE
sync desktop electron version

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -80,7 +80,7 @@
     "webpack-merge": "^5.8.0"
   },
   "build": {
-    "electronVersion": "17.4.2",
+    "electronVersion": "21.2.3",
     "appId": "org.standardnotes.standardnotes",
     "artifactName": "standard-notes-${version}-${os}-${arch}.${ext}",
     "afterSign": "scripts/notarizeMac.js",


### PR DESCRIPTION
It makes no sense to depend on electron on one version while build against another