### PR TITLE
ContentListItem accessibility bug

### DIFF
--- a/packages/web/src/javascripts/Components/ContentListView/FileListItem.tsx
+++ b/packages/web/src/javascripts/Components/ContentListView/FileListItem.tsx
@@ -81,6 +81,7 @@ const FileListItemCard: FunctionComponent<DisplayableListItemProps<FileItem>> = 
   return (
     <div
       ref={listItemRef}
+      role="button"
       className={classNames(
         'content-list-item flex w-full cursor-pointer items-stretch text-text',
         selected && 'selected border-l-2px border-solid border-info',

--- a/packages/web/src/javascripts/Components/ContentListView/NoteListItem.tsx
+++ b/packages/web/src/javascripts/Components/ContentListView/NoteListItem.tsx
@@ -103,6 +103,7 @@ const NoteListItem: FunctionComponent<DisplayableListItemProps<SNNote>> = ({
   return (
     <div
       ref={listItemRef}
+      role="button"
       className={classNames(
         'content-list-item flex w-full cursor-pointer items-stretch text-text',
         selected && `selected border-l-2 border-solid border-accessory-tint-${tint}`,


### PR DESCRIPTION
When attempting to access Standard Notes via a screen reader, the list of notes for a given tag are not detected as being clickable elements because they are defined as `div` elements instead of `input` or `button` elements:

![image](https://github.com/standardnotes/app/assets/6633831/5c0196d2-1a5c-4670-a829-eb4efdc05cac)

This PR just adds `role="button"` to them so that they are properly detected by screen readers as clickable elements.