### PR TITLE
increase the margins of headings in the super editor

### DIFF
--- a/packages/web/src/javascripts/Components/SuperEditor/Lexical/Theme/editor.scss
+++ b/packages/web/src/javascripts/Components/SuperEditor/Lexical/Theme/editor.scss
@@ -35,18 +35,18 @@
   font-size: 26px;
   color: var(--sn-stylekit-editor-foreground-color);
   font-weight: 700;
-  margin: 0;
+  margin: 20px 0 10px 0;
 }
 .Lexical__h2 {
   font-size: 22px;
   color: var(--sn-stylekit-editor-foreground-color);
   font-weight: 700;
-  margin: 0;
+  margin: 16px 0 8px 0;
 }
 .Lexical__h3 {
   font-size: 19px;
   font-weight: 700;
-  margin: 0;
+  margin: 12px 0 6px 0;
 }
 .Lexical__textBold {
   font-weight: bold;


### PR DESCRIPTION
# What
This PR increases the margins of headings in the super editor.

# Why
With the current formatting of the super editor, bigger text documents with several paragraphs, headings, lists, etc. are not as legible as they could be. Bigger margins for the headings make it easier to distinguish different sections of the document.

# Thoughts
I realize that formatting is always a subjective thing. If you don't feel like this change would be welcome by the majority of users, feel free to decline it.

I've tested the changes on the Linux App and the Android App and I'm happy with the changes.

# Screenshots
## Before
![HeadingMargins_Before](https://github.com/standardnotes/app/assets/1915778/c51e6479-2332-41c5-9cf8-b22f9a7883ca)
## After
![HeadingMargins_After](https://github.com/standardnotes/app/assets/1915778/380af710-817e-4183-81ff-ad9761df6ccd)