### PR TITLE
increase the margins of paragraphs in the super editor

### DIFF
--- a/packages/web/src/javascripts/Components/SuperEditor/Lexical/Theme/editor.scss
+++ b/packages/web/src/javascripts/Components/SuperEditor/Lexical/Theme/editor.scss
@@ -7,7 +7,7 @@
   text-align: right;
 }
 .Lexical__paragraph {
-  margin: 0;
+  margin: 6px 0 6px 0;
   position: relative;
 }
 .Lexical__quote {


### PR DESCRIPTION
# What
This PR increases the margins of paragraphs in the super editor.

# Why
With the current formatting of the super editor, bigger text documents with several paragraphs, headings, lists, etc. are not as legible as they could be. Bigger margins for the paragraphs helps in two ways. First, it makes it visually more obvious that two consecutive paragraphs are indeed two paragraphs and not one. Second, it visually separates lists that sit between two paragraphs from those paragraphs.

# Thoughts
You could also implement this by only adding a top or bottom margin to the paragraphs (I didn't research, which is the more common way). However, then you would still need to add some margin for one side of a list. Unfortunately, the css class for lists (Lexical__ul) is not only used for the list as a whole, but also for each indent. So setting a list margin would introduce unwanted changes within lists.

I realize that formatting is always a subjective thing. If you don't feel like this change would be welcome by the majority of users, feel free to decline it.

I've tested the changes on the Linux App and the Android App and I'm happy with the changes.

# Screenshots
## Before
![ParagraphMargins_Before](https://github.com/standardnotes/app/assets/1915778/f1d85bc2-0b46-43d9-83cd-c0c98baf2eb0)
## After
![ParagraphMargins_After](https://github.com/standardnotes/app/assets/1915778/b8055134-c05b-47f0-925f-927557a7358a)