### PR TITLE
replace ->,<- and <-> by the matching arrow characters in super notes

### DIFF
--- a/packages/web/src/javascripts/Components/SuperEditor/MarkdownTransformers.ts
+++ b/packages/web/src/javascripts/Components/SuperEditor/MarkdownTransformers.ts
@@ -25,7 +25,7 @@ import {
   $createHorizontalRuleNode,
   $isHorizontalRuleNode,
 } from '@lexical/react/LexicalHorizontalRuleNode'
-import { $isParagraphNode, $isTextNode, LexicalNode } from 'lexical'
+import { $isParagraphNode, $isTextNode, LexicalNode, $createTextNode } from 'lexical'
 import {
   $createRemoteImageNode,
   $isRemoteImageNode,
@@ -70,6 +70,42 @@ const IMAGE: TextMatchTransformer = {
     textNode.replace(imageNode)
   },
   trigger: ')',
+  type: 'text-match',
+}
+
+export const ARROW_DOUBLE: TextMatchTransformer = {
+  dependencies: [],
+  export: () => null,
+  importRegExp: /<-> /,
+  regExp: /<-> $/,
+  replace: (textNode) => {
+    textNode.replace($createTextNode('↔ '))
+  },
+  trigger: ' ',
+  type: 'text-match',
+}
+
+export const ARROW_RIGHT: TextMatchTransformer = {
+  dependencies: [],
+  export: () => null,
+  importRegExp: /-> /,
+  regExp: /-> $/,
+  replace: (textNode) => {
+    textNode.replace($createTextNode('→ '))
+  },
+  trigger: ' ',
+  type: 'text-match',
+}
+
+export const ARROW_LEFT: TextMatchTransformer = {
+  dependencies: [],
+  export: () => null,
+  importRegExp: /<- /,
+  regExp: /<- $/,
+  replace: (textNode) => {
+    textNode.replace($createTextNode('← '))
+  },
+  trigger: ' ',
   type: 'text-match',
 }
 
@@ -246,6 +282,9 @@ export const MarkdownTransformers = [
   CHECK_LIST,
   IMAGE,
   INLINE_FILE,
+  ARROW_DOUBLE,
+  ARROW_RIGHT,
+  ARROW_LEFT,
   ...ELEMENT_TRANSFORMERS,
   ...TEXT_FORMAT_TRANSFORMERS,
   ...TEXT_MATCH_TRANSFORMERS,


### PR DESCRIPTION
# What
This PR adds an automatic replacement in the super editor when typing `-> `, `<- ` or `<-> ` by the corresponding arrow character.

# Why
Personally I use a lot of → arrows in my texts to indicate a flow or an outcome of an action. The arrow characters are visually more pleasing to use, but are more difficult to type. This feature is present in the [Rich Markdown Editor](https://github.com/arturolinares/sn-rme), which I have used almost exclusively for the last couple years in StandardNotes. This automatic replacement speeds up the typing / search for the characters to copy and paste.

# Thoughts
The replacement is triggered when typing a space character, so shouldn't be a problem in case the characters are used inside of any string. The replacement only happens at the current position of typing, not in multiple places in the same line that all get matched with the regex. Without the $ in the regex the cursor would jump to the first match in the line and not replace the currently typed characters.

I used the [emoji plugin](https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/plugins/EmojisPlugin/index.ts) from the lexical playground as a guide of how to implement this feature, because it does something very similar. However, I chose not to implement a list/map for the different arrows like the emoji plugin did, because that implementation is buggy and can lead to the application becoming unresponsive or even crashing in certain circumstances (when the regex matches strings that are not present in the map). The only stable way I've found to implement this, is by adding three separate transformers with exactly matching regex.

I've tested the changes on the Linux app and the Android app and I'm happy with the changes.