### PR TITLE
Bugfix: Fix Simplenote importer not titling multi-line documents

### DIFF
--- a/packages/ui-services/src/Import/SimplenoteConverter/SimplenoteConverter.spec.ts
+++ b/packages/ui-services/src/Import/SimplenoteConverter/SimplenoteConverter.spec.ts
@@ -40,7 +40,7 @@ describe('SimplenoteConverter', () => {
     expect(result?.[1].uuid).not.toBeNull()
     expect(result?.[1].content_type).toBe('Note')
     expect(result?.[1].content.title).toBe('Testing 2')
-    expect(result?.[1].content.text).toBe("This is the 2nd note's content.")
+    expect(result?.[1].content.text).toBe("This is...\r\nthe 2nd note's content.")
     expect(result?.[1].content.trashed).toBe(false)
 
     expect(result?.[2].created_at).toBeInstanceOf(Date)

--- a/packages/ui-services/src/Import/SimplenoteConverter/SimplenoteConverter.ts
+++ b/packages/ui-services/src/Import/SimplenoteConverter/SimplenoteConverter.ts
@@ -15,6 +15,17 @@ type SimplenoteData = {
 const isSimplenoteEntry = (entry: any): boolean =>
   entry.id && entry.content != undefined && entry.creationDate && entry.lastModified
 
+const splitAtFirst = (str: string, delim: string): [string, string] | [] => {
+  const indexOfDelimiter = str.indexOf(delim)
+  const hasDelimiter = indexOfDelimiter > -1
+  if (!hasDelimiter) {
+    return []
+  }
+  const before = str.slice(0, indexOfDelimiter)
+  const after = str.slice(indexOfDelimiter + delim.length)
+  return [before, after]
+}
+
 export class SimplenoteConverter implements Converter {
   constructor() {}
 
@@ -58,17 +69,15 @@ export class SimplenoteConverter implements Converter {
     const createdAtDate = new Date(item.creationDate)
     const updatedAtDate = new Date(item.lastModified)
 
-    const splitItemContent = item.content.split('\r\n')
-    const hasTitleAndContent = splitItemContent.length === 2
-    const title =
-      hasTitleAndContent && splitItemContent[0].length ? splitItemContent[0] : createdAtDate.toLocaleString()
-    const content = hasTitleAndContent && splitItemContent[1].length ? splitItemContent[1] : item.content
+    const splitContent = splitAtFirst(item.content, '\r\n')
+    const title = splitContent[0] ?? createdAtDate.toLocaleString()
+    const text = splitContent[1] ?? item.content
 
     return createNote({
       createdAt: createdAtDate,
       updatedAt: updatedAtDate,
       title,
-      text: content,
+      text,
       trashed,
       useSuperIfPossible: true,
     })

--- a/packages/ui-services/src/Import/SimplenoteConverter/testData.ts
+++ b/packages/ui-services/src/Import/SimplenoteConverter/testData.ts
@@ -2,7 +2,7 @@ const data = {
   activeNotes: [
     {
       id: '43349052-4efa-48c2-bdd6-8323124451b1',
-      content: "Testing 2\r\nThis is the 2nd note's content.",
+      content: "Testing 2\r\nThis is...\r\nthe 2nd note's content.",
       creationDate: '2020-06-08T21:28:43.856Z',
       lastModified: '2021-04-16T06:21:53.124Z',
     },


### PR DESCRIPTION
SimplenoteConverter has a bug which causes it to only parse a title in notes which have *exactly* two lines. This is one of the issues addressed by [jamesgecko/simple-to-standard](https://github.com/jamesgecko/simple-to-standard).

Example data:
```json
{
  "activeNotes": [
    {
      "id": "bb33231fc77e49e9b2f66b5d07b1159d",
      "content": "Title One\r\nThis note has a title and one line of body!",
      "..."
    },
    {
      "id": "53c79c16-896f-43e5-80e5-a0f92c85330d",
      "content": "Title Two\r\nThis note has a title and...\r\nmultiple lines...\r\nof body!",
     "..."
    },
    {
      "id": "1b105f4d24534d329ca8d99439219685",
      "content": "\r\nThis note has only a body!",
      "..."
    },
  ],
  "..."
}
```

Current behavior: the second note is given a title.
<img width="500" alt="Screenshot of Standard Notes running locally. The second note imported with the date as its title." src="https://github.com/standardnotes/app/assets/4561733/43f2b832-d740-4ebe-843a-39cb8ed75d68">

This PR fixes that issue by replacing an instance of String.prototype.split with a new helper function, splitOnce, which splits a string only on the first occurrence of the delimiter.

After fix: multi-line notes are titled correctly.
<img width="500" alt="Screenshot of Standard Notes running locally. The second note imported with the correct title." src="https://github.com/standardnotes/app/assets/4561733/80429cbb-1c15-49f5-b9d6-8e288686f997">