### PR TITLE
Fixes web build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ Questions? Find answers on our [Help page](https://standardnotes.com/help).
 
 Our web app is compiled into a folder of static HTML, JS, and CSS files. You can serve these files behind a web server to get started:
 
-1. Clone the repo
-2. `cd packages/web`
-3. `yarn build`
-4. `cd dist`
-5. You can then use Python to serve this folder over http: `python -m http.server 8080`
+1. `git clone https://github.com/standardnotes/app.git`
+2. `cd app`
+3. `yarn install`
+4. `yarn build:web`
+5. `cd packages/web`
+6. You can then use Python to serve this folder over http: `python -m http.server 8080`
 
 You can now access the app at `http://localhost:8080`.
 


### PR DESCRIPTION
The instructions to build the web app don't actually work.  You need to do `yarn install` in the root, and you also need to do the `yarn build:web` from the root or else dependency projects aren't correctly built.

To reproduce the problem, you can do this in docker and see it fail:
```Dockerfile
FROM node:20.11.1-alpine3.18
RUN apk add --no-cache git python3 make g++
RUN git clone https://github.com/standardnotes/app.git
WORKDIR /app/packages/web
RUN yarn build
```
Note that this will fail, but the following will not:
```Dockerfile
FROM node:20.11.1-alpine3.18
RUN apk add --no-cache git python3 make g++
RUN git clone https://github.com/standardnotes/app.git
WORKDIR /app
RUN yarn install
RUN yarn build:web
```