### PR TITLE
chore(web): remove unused setting for failed email backups - skip e2e

### DIFF
--- a/packages/snjs/lib/Services/Settings/SettingsList.ts
+++ b/packages/snjs/lib/Services/Settings/SettingsList.ts
@@ -2,7 +2,6 @@ import { SettingName } from '@standardnotes/domain-core'
 import { SettingData } from '@standardnotes/responses'
 import {
   MuteSignInEmailsOption,
-  MuteFailedBackupsEmailsOption,
   EmailBackupFrequency,
   ListedAuthorSecretsData,
   LogSessionUserAgentOption,
@@ -13,7 +12,6 @@ type SettingType =
   | EmailBackupFrequency
   | ListedAuthorSecretsData
   | LogSessionUserAgentOption
-  | MuteFailedBackupsEmailsOption
   | MuteSignInEmailsOption
   | MuteMarketingEmailsOption
 

--- a/packages/snjs/mocha/settings.test.js
+++ b/packages/snjs/mocha/settings.test.js
@@ -123,12 +123,12 @@ describe('settings service', function () {
       true,
     )
     await application.settings.updateSetting(
-      SettingName.create(SettingName.NAMES.MuteFailedBackupsEmails).getValue(),
-      MuteFailedBackupsEmailsOption.Muted,
+      SettingName.create(SettingName.NAMES.LogSessionUserAgent).getValue(),
+      LogSessionUserAgentOption.Enabled,
     )
     const settings = await application.settings.listSettings()
-    expect(settings.getSettingValue(SettingName.create(SettingName.NAMES.MuteFailedBackupsEmails).getValue())).to.eql(
-      MuteFailedBackupsEmailsOption.Muted,
+    expect(settings.getSettingValue(SettingName.create(SettingName.NAMES.LogSessionUserAgent).getValue())).to.eql(
+      LogSessionUserAgentOption.Enabled,
     )
     expect(settings.getSettingValue(SettingName.create(SettingName.NAMES.MfaSecret).getValue())).to.not.be.ok
   })

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Backups/EmailBackups.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Backups/EmailBackups.tsx
@@ -1,4 +1,4 @@
-import { convertStringifiedBooleanToBoolean, isDesktopApplication } from '@/Utils'
+import { isDesktopApplication } from '@/Utils'
 import { STRING_FAILED_TO_UPDATE_USER_SETTING } from '@/Constants/Strings'
 import { useCallback, useEffect, useState } from 'react'
 import { WebApplication } from '@/Application/WebApplication'
@@ -6,9 +6,7 @@ import { observer } from 'mobx-react-lite'
 import { Subtitle, Text, Title } from '@/Components/Preferences/PreferencesComponents/Content'
 import Dropdown from '@/Components/Dropdown/Dropdown'
 import { DropdownItem } from '@/Components/Dropdown/DropdownItem'
-import Switch from '@/Components/Switch/Switch'
-import HorizontalSeparator from '@/Components/Shared/HorizontalSeparator'
-import { EmailBackupFrequency, MuteFailedBackupsEmailsOption, SettingName } from '@standardnotes/snjs'
+import { EmailBackupFrequency, SettingName } from '@standardnotes/snjs'
 import PreferencesGroup from '../../PreferencesComponents/PreferencesGroup'
 import PreferencesSegment from '../../PreferencesComponents/PreferencesSegment'
 import Spinner from '@/Components/Spinner/Spinner'
@@ -21,7 +19,6 @@ const EmailBackups = ({ application }: Props) => {
   const [isLoading, setIsLoading] = useState(false)
   const [emailFrequency, setEmailFrequency] = useState<EmailBackupFrequency>(EmailBackupFrequency.Disabled)
   const [emailFrequencyOptions, setEmailFrequencyOptions] = useState<DropdownItem[]>([])
-  const [isFailedBackupEmailMuted, setIsFailedBackupEmailMuted] = useState(true)
   const hasAccount = application.hasAccount()
 
   const loadEmailFrequencySetting = useCallback(async () => {
@@ -36,14 +33,6 @@ const EmailBackups = ({ application }: Props) => {
         userSettings.getSettingValue<EmailBackupFrequency>(
           SettingName.create(SettingName.NAMES.EmailBackupFrequency).getValue(),
           EmailBackupFrequency.Disabled,
-        ),
-      )
-      setIsFailedBackupEmailMuted(
-        convertStringifiedBooleanToBoolean(
-          userSettings.getSettingValue<MuteFailedBackupsEmailsOption>(
-            SettingName.create(SettingName.NAMES.MuteFailedBackupsEmails).getValue(),
-            MuteFailedBackupsEmailsOption.NotMuted,
-          ),
         ),
       )
     } catch (error) {
@@ -90,19 +79,6 @@ const EmailBackups = ({ application }: Props) => {
     }
   }
 
-  const toggleMuteFailedBackupEmails = async () => {
-    const previousValue = isFailedBackupEmailMuted
-    setIsFailedBackupEmailMuted(!isFailedBackupEmailMuted)
-
-    const updateResult = await updateSetting(
-      SettingName.create(SettingName.NAMES.MuteFailedBackupsEmails).getValue(),
-      `${!isFailedBackupEmailMuted}`,
-    )
-    if (!updateResult) {
-      setIsFailedBackupEmailMuted(previousValue)
-    }
-  }
-
   const handleEmailFrequencyChange = (item: string) => {
     updateEmailFrequency(item as EmailBackupFrequency).catch(console.error)
   }
@@ -130,18 +106,6 @@ const EmailBackups = ({ application }: Props) => {
                 value={emailFrequency}
                 onChange={handleEmailFrequencyChange}
               />
-            )}
-          </div>
-          <HorizontalSeparator classes="my-4" />
-          <Subtitle>Email preferences</Subtitle>
-          <div className="flex justify-between gap-2 md:items-center">
-            <div className="flex flex-col">
-              <Text>Receive a notification email if an email backup fails.</Text>
-            </div>
-            {isLoading ? (
-              <Spinner className="h-5 w-5 flex-shrink-0" />
-            ) : (
-              <Switch onChange={toggleMuteFailedBackupEmails} checked={!isFailedBackupEmailMuted} />
             )}
           </div>
         </div>


### PR DESCRIPTION
This setting is no longer interpreted on the server side thus it's not needed in the UI