### PR TITLE
Update Super Notes to prevent code blocks from wrapping

### DIFF
--- a/packages/web/src/javascripts/Components/SuperEditor/Lexical/Theme/editor.scss
+++ b/packages/web/src/javascripts/Components/SuperEditor/Lexical/Theme/editor.scss
@@ -6,6 +6,9 @@
 .Lexical__rtl {
   text-align: right;
 }
+.Lexical__code {
+  white-space: pre;
+}
 .Lexical__paragraph {
   margin: 0;
   position: relative;


### PR DESCRIPTION
Before:
![image](https://github.com/standardnotes/app/assets/778012/c32ed9a2-a9ef-4235-bd0d-ba55b88bf3a3)

After:
![image](https://github.com/standardnotes/app/assets/778012/99f22bef-efff-47f4-9872-922495525bcc)
![image](https://github.com/standardnotes/app/assets/778012/f231ddee-fb6e-41d8-b9e2-13eb39ff3dab)

This brings Standard Notes in line with the GitHub code block behavior when overflow occurs:
```
Here's usage information for git remote:
usage: git remote [-v | --verbose]
  or: git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--mirror=<fetch|push>] <name> <url>
  or: git remote rename [--[no-]progress] <old> <new>
  or: git remote remove <name>
  or: git remote set-head <name> (-a | --auto | -d | --delete | <branch>)
  or: git remote [-v | --verbose] show [-n] <name>
  or: git remote prune [-n | --dry-run] <name>
  or: git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]
  or: git remote set-branches [--add] <name> <branch>...
  or: git remote get-url [--push] [--all] <name>
  or: git remote set-url [--push] <name> <newurl> [<oldurl>]
  or: git remote set-url --add <name> <newurl>
  or: git remote set-url --delete <name> <url>

   -v, --[no-]verbose    be verbose; must be placed before a subcommand
```