### PR TITLE
feat: add 10 minute option in LockInterval

### DIFF
--- a/packages/ui-services/src/Security/AutolockService.ts
+++ b/packages/ui-services/src/Security/AutolockService.ts
@@ -13,6 +13,7 @@ const LockInterval = {
   Immediate: 1,
   OneMinute: 60 * MILLISECONDS_PER_SECOND,
   FiveMinutes: 300 * MILLISECONDS_PER_SECOND,
+  TenMinutes: 600 * MILLISECONDS_PER_SECOND,
   OneHour: 3600 * MILLISECONDS_PER_SECOND,
 }
 
@@ -132,6 +133,10 @@ export class AutolockService extends AbstractService {
       {
         value: LockInterval.FiveMinutes,
         label: '5m',
+      },
+      {
+        value: LockInterval.TenMinutes,
+        label: '10m',
       },
       {
         value: LockInterval.OneHour,


### PR DESCRIPTION
This fixes: https://github.com/standardnotes/forum/issues/3638 (custom auto-lock time or just 10 minute lock is fine for me)  
This fixes: https://github.com/standardnotes/forum/discussions/3645  

Imagine you go to a coffee shop and they have the best coffee in town, but the chair sucks in a sense that it doesn't allow you to lean back on it, which makes you disappointed because everything in the coffee shop is perfect, except for the chair. 
The auto lock options is the chair.

I am an avid user of this product and with this feature I would be happy, and I'm not just a random person, we need to take into account the "silent minority", that is, people who want this feature but don't have patience or knowledge to "fight" for it. 

Also, in the discussion link I sent, @thezacharytaylor agrees with me:  
https://github.com/standardnotes/forum/discussions/3645#discussioncomment-10035038  

I have not tested this code locally, but I presume it would work.