### PR TITLE
fix: toggle notes panel

### DIFF
--- a/packages/web/src/javascripts/Components/Panes/PanesSystemComponent.tsx
+++ b/packages/web/src/javascripts/Components/Panes/PanesSystemComponent.tsx
@@ -207,7 +207,7 @@ const PanesSystemComponent = () => {
             }
           } else {
             return {
-              gridTemplateColumns: `${itemsPanelWidth}px auto`,
+              gridTemplateColumns: `${itemsPanelWidth || ITEMS_PANEL_DEFAULT_WIDTH}px auto`,
             }
           }
         }
@@ -219,7 +219,7 @@ const PanesSystemComponent = () => {
           }
         }
         return {
-          gridTemplateColumns: `${navigationPanelWidth}px ${itemsPanelWidth}px 2fr`,
+          gridTemplateColumns: `${navigationPanelWidth}px ${itemsPanelWidth || ITEMS_PANEL_DEFAULT_WIDTH}px 2fr`,
         }
       }
       default:


### PR DESCRIPTION
This fixes the issue mentioned here: https://github.com/standardnotes/forum/issues/3754

Somehow `itemsPanelResizeWidthChangeCallback` returns 0 and so `itemsPanelWidth` is also 0 and therefore the panel is not shown.
This could be due to an error in the `ContentListView.tsx` file, which I was not able to find.

However, I added this kind of workaround so now it works flawlessly.
If somebody knows a better solution, please let me know and I will be happy to change it accordingly.