### PR TITLE
fix: keep panes settings after reload

### DIFF
--- a/packages/services/src/Domain/Preferences/LocalPrefKey.ts
+++ b/packages/services/src/Domain/Preferences/LocalPrefKey.ts
@@ -43,7 +43,7 @@ export const LocalPrefDefaults = {
   [LocalPrefKey.EditorMonospaceEnabled]: false,
   [LocalPrefKey.EditorLineHeight]: EditorLineHeight.Normal,
   [LocalPrefKey.EditorLineWidth]: EditorLineWidth.FullWidth,
-  [LocalPrefKey.EditorFontSize]: EditorFontSize.Normal
+  [LocalPrefKey.EditorFontSize]: EditorFontSize.Normal,
 } satisfies {
   [key in LocalPrefKey]: LocalPrefValue[key]
 }

--- a/packages/services/src/Domain/Preferences/LocalPrefKey.ts
+++ b/packages/services/src/Domain/Preferences/LocalPrefKey.ts
@@ -1,6 +1,8 @@
 import { EditorFontSize, EditorLineHeight, EditorLineWidth } from '@standardnotes/models'
 
 export enum LocalPrefKey {
+  ListPaneCollapsed = 'listPaneCollapsed',
+  NavigationPaneCollapsed = 'navigationPaneCollapsed',
   ActiveThemes = 'activeThemes',
   UseSystemColorScheme = 'useSystemColorScheme',
   UseTranslucentUI = 'useTranslucentUI',
@@ -14,6 +16,8 @@ export enum LocalPrefKey {
 }
 
 export type LocalPrefValue = {
+  [LocalPrefKey.ListPaneCollapsed]: boolean
+  [LocalPrefKey.NavigationPaneCollapsed]: boolean
   [LocalPrefKey.ActiveThemes]: string[]
   [LocalPrefKey.UseSystemColorScheme]: boolean
   [LocalPrefKey.UseTranslucentUI]: boolean
@@ -24,4 +28,9 @@ export type LocalPrefValue = {
   [LocalPrefKey.EditorLineHeight]: EditorLineHeight
   [LocalPrefKey.EditorLineWidth]: EditorLineWidth
   [LocalPrefKey.EditorFontSize]: EditorFontSize
+}
+
+export const LocalPrefDefaults = {
+  listPaneCollapsed: false,
+  navigationPaneCollapsed: false
 }

--- a/packages/services/src/Domain/Preferences/LocalPrefKey.ts
+++ b/packages/services/src/Domain/Preferences/LocalPrefKey.ts
@@ -1,4 +1,5 @@
 import { EditorFontSize, EditorLineHeight, EditorLineWidth } from '@standardnotes/models'
+import { NativeFeatureIdentifier } from '@standardnotes/features'
 
 export enum LocalPrefKey {
   ListPaneCollapsed = 'listPaneCollapsed',
@@ -31,6 +32,18 @@ export type LocalPrefValue = {
 }
 
 export const LocalPrefDefaults = {
-  listPaneCollapsed: false,
-  navigationPaneCollapsed: false
+  [LocalPrefKey.ListPaneCollapsed]: false,
+  [LocalPrefKey.NavigationPaneCollapsed]: false,
+  [LocalPrefKey.ActiveThemes]: [],
+  [LocalPrefKey.UseSystemColorScheme]: false,
+  [LocalPrefKey.UseTranslucentUI]: true,
+  [LocalPrefKey.AutoLightThemeIdentifier]: 'Default',
+  [LocalPrefKey.AutoDarkThemeIdentifier]: NativeFeatureIdentifier.TYPES.DarkTheme,
+
+  [LocalPrefKey.EditorMonospaceEnabled]: false,
+  [LocalPrefKey.EditorLineHeight]: EditorLineHeight.Normal,
+  [LocalPrefKey.EditorLineWidth]: EditorLineWidth.FullWidth,
+  [LocalPrefKey.EditorFontSize]: EditorFontSize.Normal
+} satisfies {
+  [key in LocalPrefKey]: LocalPrefValue[key]
 }

--- a/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
+++ b/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
@@ -2,6 +2,8 @@ import { PanesForLayout } from './../../Application/UseCase/PanesForLayout'
 import {
   InternalEventHandlerInterface,
   InternalEventInterface,
+  LocalPrefDefaults,
+  LocalPrefKey,
   PreferenceServiceInterface,
 } from '@standardnotes/services'
 import {
@@ -42,8 +44,8 @@ export class PaneController extends AbstractViewController implements InternalEv
   currentItemsPanelWidth = 0
   focusModeEnabled = false
 
-  listPaneExplicitelyCollapsed = localStorage.getItem("listPaneCollapsed")=="true"
-  navigationPaneExplicitelyCollapsed = localStorage.getItem("navPaneCollapsed")=="true"
+  listPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.ListPaneCollapsed, LocalPrefDefaults[LocalPrefKey.ListPaneCollapsed])
+  navigationPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.NavigationPaneCollapsed, LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed])
 
   constructor(
     private preferences: PreferenceServiceInterface,
@@ -106,6 +108,7 @@ export class PaneController extends AbstractViewController implements InternalEv
     }
 
     eventBus.addEventHandler(this, ApplicationEvent.PreferencesChanged)
+    eventBus.addEventHandler(this, ApplicationEvent.LocalPreferencesChanged)
 
     this.disposers.push(
       keyboardService.addCommandHandler({
@@ -143,6 +146,10 @@ export class PaneController extends AbstractViewController implements InternalEv
     if (event.type === ApplicationEvent.PreferencesChanged) {
       this.setCurrentNavPanelWidth(this.preferences.getValue(PrefKey.TagsPanelWidth, MinimumNavPanelWidth))
       this.setCurrentItemsPanelWidth(this.preferences.getValue(PrefKey.NotesPanelWidth, MinimumNotesPanelWidth))
+    }
+    if(event.type === ApplicationEvent.LocalPreferencesChanged){
+      this.listPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.ListPaneCollapsed, LocalPrefDefaults[LocalPrefKey.ListPaneCollapsed])
+      this.navigationPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.NavigationPaneCollapsed, LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed])
     }
   }
 
@@ -258,28 +265,24 @@ export class PaneController extends AbstractViewController implements InternalEv
   toggleListPane = () => {
     if (this.panes.includes(AppPaneId.Items)) {
       this.removePane(AppPaneId.Items)
-      this.listPaneExplicitelyCollapsed = true
-      localStorage.setItem("listPaneCollapsed", "true")
+      this.preferences.setLocalValue(LocalPrefKey.ListPaneCollapsed, true)
     } else {
       if (this.panes.includes(AppPaneId.Navigation)) {
         this.insertPaneAtIndex(AppPaneId.Items, 1)
       } else {
         this.insertPaneAtIndex(AppPaneId.Items, 0)
       }
-      this.listPaneExplicitelyCollapsed = false
-      localStorage.setItem("listPaneCollapsed", "false")
+      this.preferences.setLocalValue(LocalPrefKey.ListPaneCollapsed, false)
     }
   }
 
   toggleNavigationPane = () => {
     if (this.panes.includes(AppPaneId.Navigation)) {
       this.removePane(AppPaneId.Navigation)
-      this.navigationPaneExplicitelyCollapsed = true
-      localStorage.setItem("navPaneCollapsed", "true")
+      this.preferences.setLocalValue(LocalPrefKey.NavigationPaneCollapsed, true)
     } else {
       this.insertPaneAtIndex(AppPaneId.Navigation, 0)
-      this.navigationPaneExplicitelyCollapsed = false
-      localStorage.setItem("navPaneCollapsed", "false")
+      this.preferences.setLocalValue(LocalPrefKey.NavigationPaneCollapsed, false)
     }
   }
 

--- a/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
+++ b/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
@@ -44,8 +44,14 @@ export class PaneController extends AbstractViewController implements InternalEv
   currentItemsPanelWidth = 0
   focusModeEnabled = false
 
-  listPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.ListPaneCollapsed, LocalPrefDefaults[LocalPrefKey.ListPaneCollapsed])
-  navigationPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.NavigationPaneCollapsed, LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed])
+  listPaneExplicitelyCollapsed = this.preferences.getLocalValue(
+    LocalPrefKey.ListPaneCollapsed,
+    LocalPrefDefaults[LocalPrefKey.ListPaneCollapsed],
+  )
+  navigationPaneExplicitelyCollapsed = this.preferences.getLocalValue(
+    LocalPrefKey.NavigationPaneCollapsed,
+    LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed],
+  )
 
   constructor(
     private preferences: PreferenceServiceInterface,
@@ -147,9 +153,15 @@ export class PaneController extends AbstractViewController implements InternalEv
       this.setCurrentNavPanelWidth(this.preferences.getValue(PrefKey.TagsPanelWidth, MinimumNavPanelWidth))
       this.setCurrentItemsPanelWidth(this.preferences.getValue(PrefKey.NotesPanelWidth, MinimumNotesPanelWidth))
     }
-    if(event.type === ApplicationEvent.LocalPreferencesChanged){
-      this.listPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.ListPaneCollapsed, LocalPrefDefaults[LocalPrefKey.ListPaneCollapsed])
-      this.navigationPaneExplicitelyCollapsed = this.preferences.getLocalValue(LocalPrefKey.NavigationPaneCollapsed, LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed])
+    if (event.type === ApplicationEvent.LocalPreferencesChanged) {
+      this.listPaneExplicitelyCollapsed = this.preferences.getLocalValue(
+        LocalPrefKey.ListPaneCollapsed,
+        LocalPrefDefaults[LocalPrefKey.ListPaneCollapsed],
+      )
+      this.navigationPaneExplicitelyCollapsed = this.preferences.getLocalValue(
+        LocalPrefKey.NavigationPaneCollapsed,
+        LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed],
+      )
     }
   }
 

--- a/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
+++ b/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
@@ -42,8 +42,8 @@ export class PaneController extends AbstractViewController implements InternalEv
   currentItemsPanelWidth = 0
   focusModeEnabled = false
 
-  listPaneExplicitelyCollapsed = false
-  navigationPaneExplicitelyCollapsed = false
+  listPaneExplicitelyCollapsed = localStorage.getItem("listPaneCollapsed")=="true"
+  navigationPaneExplicitelyCollapsed = localStorage.getItem("navPaneCollapsed")=="true"
 
   constructor(
     private preferences: PreferenceServiceInterface,
@@ -86,9 +86,17 @@ export class PaneController extends AbstractViewController implements InternalEv
 
     const screen = this._isTabletOrMobileScreen.execute().getValue()
 
-    this.panes = screen.isTabletOrMobile
-      ? [AppPaneId.Navigation, AppPaneId.Items]
-      : [AppPaneId.Navigation, AppPaneId.Items, AppPaneId.Editor]
+    if (screen.isTabletOrMobile) {
+      this.panes = [AppPaneId.Navigation, AppPaneId.Items]
+    } else {
+      if (!this.listPaneExplicitelyCollapsed && !this.navigationPaneExplicitelyCollapsed) {
+        this.panes = [AppPaneId.Navigation, AppPaneId.Items, AppPaneId.Editor]
+      } else if (this.listPaneExplicitelyCollapsed) {
+        this.panes = [AppPaneId.Navigation, AppPaneId.Editor]
+      } else {
+        this.panes = [AppPaneId.Items, AppPaneId.Editor]
+      }
+    }
 
     const mediaQuery = window.matchMedia(MediaQueryBreakpoints.md)
     if (mediaQuery?.addEventListener != undefined) {
@@ -251,6 +259,7 @@ export class PaneController extends AbstractViewController implements InternalEv
     if (this.panes.includes(AppPaneId.Items)) {
       this.removePane(AppPaneId.Items)
       this.listPaneExplicitelyCollapsed = true
+      localStorage.setItem("listPaneCollapsed", "true")
     } else {
       if (this.panes.includes(AppPaneId.Navigation)) {
         this.insertPaneAtIndex(AppPaneId.Items, 1)
@@ -258,6 +267,7 @@ export class PaneController extends AbstractViewController implements InternalEv
         this.insertPaneAtIndex(AppPaneId.Items, 0)
       }
       this.listPaneExplicitelyCollapsed = false
+      localStorage.setItem("listPaneCollapsed", "false")
     }
   }
 
@@ -265,9 +275,11 @@ export class PaneController extends AbstractViewController implements InternalEv
     if (this.panes.includes(AppPaneId.Navigation)) {
       this.removePane(AppPaneId.Navigation)
       this.navigationPaneExplicitelyCollapsed = true
+      localStorage.setItem("navPaneCollapsed", "true")
     } else {
       this.insertPaneAtIndex(AppPaneId.Navigation, 0)
       this.navigationPaneExplicitelyCollapsed = false
+      localStorage.setItem("navPaneCollapsed", "false")
     }
   }
 

--- a/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
+++ b/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
@@ -43,7 +43,7 @@ export class PaneController extends AbstractViewController implements InternalEv
   currentNavPanelWidth = 0
   currentItemsPanelWidth = 0
   focusModeEnabled = false
-  isTabletOrMobile = this._isTabletOrMobileScreen.execute().getValue().isTabletOrMobile
+  hasPaneInitializationLogicRun = false
 
   listPaneExplicitelyCollapsed = this.preferences.getLocalValue(
     LocalPrefKey.ListPaneCollapsed,
@@ -151,18 +151,22 @@ export class PaneController extends AbstractViewController implements InternalEv
         LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed],
       )
 
-      if (this.isTabletOrMobile) {
-        this.panes = [AppPaneId.Navigation, AppPaneId.Items]
-      } else {
-        if (!this.listPaneExplicitelyCollapsed && !this.navigationPaneExplicitelyCollapsed) {
-          this.panes = [AppPaneId.Navigation, AppPaneId.Items, AppPaneId.Editor]
-        } else if (this.listPaneExplicitelyCollapsed && this.navigationPaneExplicitelyCollapsed) {
-          this.panes = [AppPaneId.Editor]
-        } else if (this.listPaneExplicitelyCollapsed) {
-          this.panes = [AppPaneId.Navigation, AppPaneId.Editor]
+      if(!this.hasPaneInitializationLogicRun) {
+        const screen = this._isTabletOrMobileScreen.execute().getValue()
+        if (screen.isTabletOrMobile) {
+          this.panes = [AppPaneId.Navigation, AppPaneId.Items]
         } else {
-          this.panes = [AppPaneId.Items, AppPaneId.Editor]
+          if (!this.listPaneExplicitelyCollapsed && !this.navigationPaneExplicitelyCollapsed) {
+            this.panes = [AppPaneId.Navigation, AppPaneId.Items, AppPaneId.Editor]
+          } else if (this.listPaneExplicitelyCollapsed && this.navigationPaneExplicitelyCollapsed) {
+            this.panes = [AppPaneId.Editor]
+          } else if (this.listPaneExplicitelyCollapsed) {
+            this.panes = [AppPaneId.Navigation, AppPaneId.Editor]
+          } else {
+            this.panes = [AppPaneId.Items, AppPaneId.Editor]
+          }
         }
+        this.hasPaneInitializationLogicRun = true
       }
     }
   }

--- a/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
+++ b/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
@@ -92,19 +92,6 @@ export class PaneController extends AbstractViewController implements InternalEv
     this.setCurrentNavPanelWidth(preferences.getValue(PrefKey.TagsPanelWidth, MinimumNavPanelWidth))
     this.setCurrentItemsPanelWidth(preferences.getValue(PrefKey.NotesPanelWidth, MinimumNotesPanelWidth))
 
-    const screen = this._isTabletOrMobileScreen.execute().getValue()
-
-    if (screen.isTabletOrMobile) {
-      this.panes = [AppPaneId.Navigation, AppPaneId.Items]
-    } else {
-      if (!this.listPaneExplicitelyCollapsed && !this.navigationPaneExplicitelyCollapsed) {
-        this.panes = [AppPaneId.Navigation, AppPaneId.Items, AppPaneId.Editor]
-      } else if (this.listPaneExplicitelyCollapsed) {
-        this.panes = [AppPaneId.Navigation, AppPaneId.Editor]
-      } else {
-        this.panes = [AppPaneId.Items, AppPaneId.Editor]
-      }
-    }
 
     const mediaQuery = window.matchMedia(MediaQueryBreakpoints.md)
     if (mediaQuery?.addEventListener != undefined) {
@@ -162,6 +149,20 @@ export class PaneController extends AbstractViewController implements InternalEv
         LocalPrefKey.NavigationPaneCollapsed,
         LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed],
       )
+      const screen = this._isTabletOrMobileScreen.execute().getValue()
+      if (screen.isTabletOrMobile) {
+        this.panes = [AppPaneId.Navigation, AppPaneId.Items]
+      } else {
+        if (!this.listPaneExplicitelyCollapsed && !this.navigationPaneExplicitelyCollapsed) {
+          this.panes = [AppPaneId.Navigation, AppPaneId.Items, AppPaneId.Editor]
+        } else if (this.listPaneExplicitelyCollapsed && this.navigationPaneExplicitelyCollapsed) {
+          this.panes = [AppPaneId.Editor]
+        } else if (this.listPaneExplicitelyCollapsed) {
+          this.panes = [AppPaneId.Navigation, AppPaneId.Editor]
+        } else {
+          this.panes = [AppPaneId.Items, AppPaneId.Editor]
+        }
+      }
     }
   }
 

--- a/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
+++ b/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
@@ -43,6 +43,7 @@ export class PaneController extends AbstractViewController implements InternalEv
   currentNavPanelWidth = 0
   currentItemsPanelWidth = 0
   focusModeEnabled = false
+  isTabletOrMobile = this._isTabletOrMobileScreen.execute().getValue().isTabletOrMobile
 
   listPaneExplicitelyCollapsed = this.preferences.getLocalValue(
     LocalPrefKey.ListPaneCollapsed,
@@ -149,8 +150,8 @@ export class PaneController extends AbstractViewController implements InternalEv
         LocalPrefKey.NavigationPaneCollapsed,
         LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed],
       )
-      const screen = this._isTabletOrMobileScreen.execute().getValue()
-      if (screen.isTabletOrMobile) {
+
+      if (this.isTabletOrMobile) {
         this.panes = [AppPaneId.Navigation, AppPaneId.Items]
       } else {
         if (!this.listPaneExplicitelyCollapsed && !this.navigationPaneExplicitelyCollapsed) {

--- a/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
+++ b/packages/web/src/javascripts/Controllers/PaneController/PaneController.ts
@@ -93,7 +93,6 @@ export class PaneController extends AbstractViewController implements InternalEv
     this.setCurrentNavPanelWidth(preferences.getValue(PrefKey.TagsPanelWidth, MinimumNavPanelWidth))
     this.setCurrentItemsPanelWidth(preferences.getValue(PrefKey.NotesPanelWidth, MinimumNotesPanelWidth))
 
-
     const mediaQuery = window.matchMedia(MediaQueryBreakpoints.md)
     if (mediaQuery?.addEventListener != undefined) {
       mediaQuery.addEventListener('change', this.mediumScreenMQHandler)
@@ -151,7 +150,7 @@ export class PaneController extends AbstractViewController implements InternalEv
         LocalPrefDefaults[LocalPrefKey.NavigationPaneCollapsed],
       )
 
-      if(!this.hasPaneInitializationLogicRun) {
+      if (!this.hasPaneInitializationLogicRun) {
         const screen = this._isTabletOrMobileScreen.execute().getValue()
         if (screen.isTabletOrMobile) {
           this.panes = [AppPaneId.Navigation, AppPaneId.Items]

--- a/packages/web/src/javascripts/Hooks/usePreference.tsx
+++ b/packages/web/src/javascripts/Hooks/usePreference.tsx
@@ -1,5 +1,12 @@
 import { useApplication } from '@/Components/ApplicationProvider'
-import { ApplicationEvent, PrefKey, PrefDefaults, LocalPrefKey, LocalPrefValue, LocalPrefDefaults } from '@standardnotes/snjs'
+import {
+  ApplicationEvent,
+  PrefKey,
+  PrefDefaults,
+  LocalPrefKey,
+  LocalPrefValue,
+  LocalPrefDefaults,
+} from '@standardnotes/snjs'
 import { useCallback, useEffect, useState } from 'react'
 
 export function useLocalPreference<Key extends LocalPrefKey>(preference: Key) {

--- a/packages/web/src/javascripts/Hooks/usePreference.tsx
+++ b/packages/web/src/javascripts/Hooks/usePreference.tsx
@@ -1,11 +1,11 @@
 import { useApplication } from '@/Components/ApplicationProvider'
-import { ApplicationEvent, PrefKey, PrefDefaults, LocalPrefKey, LocalPrefValue } from '@standardnotes/snjs'
+import { ApplicationEvent, PrefKey, PrefDefaults, LocalPrefKey, LocalPrefValue, LocalPrefDefaults } from '@standardnotes/snjs'
 import { useCallback, useEffect, useState } from 'react'
 
 export function useLocalPreference<Key extends LocalPrefKey>(preference: Key) {
   const application = useApplication()
 
-  const [value, setValue] = useState(application.preferences.getLocalValue(preference, PrefDefaults[preference]))
+  const [value, setValue] = useState(application.preferences.getLocalValue(preference, LocalPrefDefaults[preference]))
 
   const setNewValue = useCallback(
     (newValue: LocalPrefValue[Key]) => {
@@ -16,7 +16,7 @@ export function useLocalPreference<Key extends LocalPrefKey>(preference: Key) {
 
   useEffect(() => {
     return application.addEventObserver(async () => {
-      const latestValue = application.preferences.getLocalValue(preference, PrefDefaults[preference])
+      const latestValue = application.preferences.getLocalValue(preference, LocalPrefDefaults[preference])
 
       setValue(latestValue)
     }, ApplicationEvent.LocalPreferencesChanged)


### PR DESCRIPTION
This fixes the issue mentioned here: https://github.com/standardnotes/forum/issues/2423

I used `localStorage` to save the changes made by toggeling the panes.
Also I edited the initialization of the `panes` array, because otherwise all three panes would show up after reload for a short time and then dissapear again depending on your settings.