### PR TITLE
fix(SNOTES-476): fix LinkedItemBubble styling

### DIFF
--- a/packages/web/src/javascripts/Components/LinkedItems/LinkedItemBubble.tsx
+++ b/packages/web/src/javascripts/Components/LinkedItems/LinkedItemBubble.tsx
@@ -113,6 +113,7 @@ const LinkedItemBubble = ({
           'bg-passive-4-opacity-variant outline-1 outline-info hover:bg-contrast focus:bg-contrast focus:outline',
           'whitespace-pre-wrap text-left text-sm text-text hover:no-underline focus:no-underline lg:text-xs',
           'py-1 pl-1 pr-2',
+          'inline-flex items-center',
           className,
         )}
         onFocus={handleFocus}


### PR DESCRIPTION
Fixes misaligned text on bubbles for linked items wrapped within the text when using the Super editor.

Before:

<img width="406" alt="Screenshot 2025-06-12 at 1 04 52 AM" src="https://github.com/user-attachments/assets/fdd21710-095f-4b0b-8374-4f3d59780ac2" />

After:

<img width="406" alt="Screenshot 2025-06-12 at 1 05 21 AM" src="https://github.com/user-attachments/assets/6e23f949-6a1f-4105-95b5-e7a01563a446" />
