### PR TITLE
fix(SNOTES-480): display tag title as string in delete dialog

### DIFF
--- a/packages/styles/src/Alert/Alert.ts
+++ b/packages/styles/src/Alert/Alert.ts
@@ -105,14 +105,14 @@ export class SKAlert {
     }
     const titleTemplate = this.title
       ? `<div class='mb-1 font-bold text-lg flex items-center justify-between'>
-          ${this.title}
+          <span id="title"></span>
           <button id="close-button" class="rounded p-1 font-bold hover:bg-contrast" onClick={closeDialog}>
             <svg class="w-5 h-5 fill-current" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.2459 5.92925C15.5704 5.60478 15.5704 5.07872 15.2459 4.75425C14.9214 4.42978 14.3954 4.42978 14.0709 4.75425L10.0001 8.82508L5.92925 4.75425C5.60478 4.42978 5.07872 4.42978 4.75425 4.75425C4.42978 5.07872 4.42978 5.60478 4.75425 5.92925L8.82508 10.0001L4.75425 14.0709C4.42978 14.3954 4.42978 14.9214 4.75425 15.2459C5.07872 15.5704 5.60478 15.5704 5.92925 15.2459L10.0001 11.1751L14.0709 15.2459C14.3954 15.5704 14.9214 15.5704 15.2459 15.2459C15.5704 14.9214 15.5704 14.3954 15.2459 14.0709L11.1751 10.0001L15.2459 5.92925Z" /></svg>
           </button>
          </div>`
       : ''
     const messageTemplate = this.text
-      ? `<p class='sk-p text-base lg:text-sm' style="max-width: 100%; overflow: hidden; text-overflow: ellipsis;">${this.text}</p>`
+      ? `<p id="message" class='sk-p text-base lg:text-sm' style="max-width: 100%; overflow: hidden; text-overflow: ellipsis;"></p>`
       : ''
 
     const template = `
@@ -163,6 +163,17 @@ export class SKAlert {
     this.element = document.createElement('div')
     this.element.className = 'sn-component'
     this.element.innerHTML = this.templateString().trim()
+
+    const titleElement = this.element.querySelector('#title')
+    const messageElement = this.element.querySelector('#message')
+
+    if (titleElement) {
+      titleElement.textContent = this.title || ''
+    }
+
+    if (messageElement) {
+      messageElement.textContent = this.text || ''
+    }
 
     onElement.appendChild(this.element)
 

--- a/packages/styles/src/Alert/Alert.ts
+++ b/packages/styles/src/Alert/Alert.ts
@@ -105,14 +105,14 @@ export class SKAlert {
     }
     const titleTemplate = this.title
       ? `<div class='mb-1 font-bold text-lg flex items-center justify-between'>
-          <span id="title"></span>
+          ${this.title}
           <button id="close-button" class="rounded p-1 font-bold hover:bg-contrast" onClick={closeDialog}>
             <svg class="w-5 h-5 fill-current" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.2459 5.92925C15.5704 5.60478 15.5704 5.07872 15.2459 4.75425C14.9214 4.42978 14.3954 4.42978 14.0709 4.75425L10.0001 8.82508L5.92925 4.75425C5.60478 4.42978 5.07872 4.42978 4.75425 4.75425C4.42978 5.07872 4.42978 5.60478 4.75425 5.92925L8.82508 10.0001L4.75425 14.0709C4.42978 14.3954 4.42978 14.9214 4.75425 15.2459C5.07872 15.5704 5.60478 15.5704 5.92925 15.2459L10.0001 11.1751L14.0709 15.2459C14.3954 15.5704 14.9214 15.5704 15.2459 15.2459C15.5704 14.9214 15.5704 14.3954 15.2459 14.0709L11.1751 10.0001L15.2459 5.92925Z" /></svg>
           </button>
          </div>`
       : ''
     const messageTemplate = this.text
-      ? `<p id="message" class='sk-p text-base lg:text-sm' style="max-width: 100%; overflow: hidden; text-overflow: ellipsis;"></p>`
+      ? `<p class='sk-p text-base lg:text-sm' style="max-width: 100%; overflow: hidden; text-overflow: ellipsis;">${this.text}</p>`
       : ''
 
     const template = `
@@ -163,17 +163,6 @@ export class SKAlert {
     this.element = document.createElement('div')
     this.element.className = 'sn-component'
     this.element.innerHTML = this.templateString().trim()
-
-    const titleElement = this.element.querySelector('#title')
-    const messageElement = this.element.querySelector('#message')
-
-    if (titleElement) {
-      titleElement.textContent = this.title || ''
-    }
-
-    if (messageElement) {
-      messageElement.textContent = this.text || ''
-    }
 
     onElement.appendChild(this.element)
 

--- a/packages/utils/src/Domain/Utils/Utils.ts
+++ b/packages/utils/src/Domain/Utils/Utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { sanitize } from 'dompurify'
-import { find, isArray, mergeWith, remove, uniq, uniqWith } from 'lodash'
+import { escape, find, isArray, mergeWith, remove, uniq, uniqWith } from 'lodash'
 import { AnyRecord } from '@standardnotes/common'
 
 const collator = typeof Intl !== 'undefined' ? new Intl.Collator('en', { numeric: true }) : undefined
@@ -610,6 +610,10 @@ export function convertTimestampToMilliseconds(timestamp: number): number {
 
 export function sanitizeHtmlString(html: string): string {
   return sanitize(html)
+}
+
+export function escapeHtmlString(html: string): string {
+  return escape(html)
 }
 
 let sharedDateFormatter: unknown

--- a/packages/web/src/javascripts/Constants/Strings.ts
+++ b/packages/web/src/javascripts/Constants/Strings.ts
@@ -161,4 +161,11 @@ export const StringUtils = {
       ? "This note has editing disabled. If you'd like to delete it, enable editing, and try again."
       : "One or more of these notes have editing disabled. If you'd like to delete them, make sure editing is enabled on all of them, and try again."
   },
+  deleteTag(title: string): string {
+    const escapedTitle = escapeHtmlString(title)
+    return `Delete tag "${escapedTitle}"?`
+  },
+  cannotUploadFile(name: string): string {
+    const escapedName = escapeHtmlString(name)
+    return `Cannot upload file "${escapedName}"`}
 }

--- a/packages/web/src/javascripts/Constants/Strings.ts
+++ b/packages/web/src/javascripts/Constants/Strings.ts
@@ -167,5 +167,6 @@ export const StringUtils = {
   },
   cannotUploadFile(name: string): string {
     const escapedName = escapeHtmlString(name)
-    return `Cannot upload file "${escapedName}"`}
+    return `Cannot upload file "${escapedName}"`
+  },
 }

--- a/packages/web/src/javascripts/Constants/Strings.ts
+++ b/packages/web/src/javascripts/Constants/Strings.ts
@@ -1,4 +1,4 @@
-import { Platform, SNApplication } from '@standardnotes/snjs'
+import { escapeHtmlString, Platform, SNApplication } from '@standardnotes/snjs'
 import { getPlatform, isDesktopApplication } from '../Utils'
 
 /** @generic */
@@ -39,9 +39,10 @@ export const STRING_EDIT_LOCKED_ATTEMPT =
 export const STRING_RESTORE_LOCKED_ATTEMPT =
   "This note has editing disabled. If you'd like to restore it to a previous revision, enable editing and try again."
 export function StringDeleteNote(title: string, permanently: boolean) {
+  const escapedTitle = escapeHtmlString(title)
   return permanently
-    ? `Are you sure you want to permanently delete ${title}?`
-    : `Are you sure you want to move ${title} to the trash?`
+    ? `Are you sure you want to permanently delete ${escapedTitle}?`
+    : `Are you sure you want to move ${escapedTitle} to the trash?`
 }
 export function StringEmptyTrash(count: number) {
   return `Are you sure you want to permanently delete ${count} note(s)?`
@@ -135,9 +136,10 @@ export const StringUtils = {
   },
   deleteNotes(permanently: boolean, notesCount = 1, title?: string): string {
     if (notesCount === 1) {
+      const escapedTitle = escapeHtmlString(title || '')
       return permanently
-        ? `Are you sure you want to permanently delete ${title}?`
-        : `Are you sure you want to move ${title} to the trash?`
+        ? `Are you sure you want to permanently delete ${escapedTitle}?`
+        : `Are you sure you want to move ${escapedTitle} to the trash?`
     } else {
       return permanently
         ? 'Are you sure you want to permanently delete these notes?'
@@ -145,7 +147,8 @@ export const StringUtils = {
     }
   },
   deleteFile(title: string): string {
-    return `Are you sure you want to permanently delete ${title}?`
+    const escapedTitle = escapeHtmlString(title)
+    return `Are you sure you want to permanently delete ${escapedTitle}?`
   },
   archiveLockedNotesAttempt(archive: boolean, notesCount = 1): string {
     const archiveString = archive ? 'archive' : 'unarchive'

--- a/packages/web/src/javascripts/Controllers/FilesController.ts
+++ b/packages/web/src/javascripts/Controllers/FilesController.ts
@@ -16,7 +16,7 @@ import {
 import { Strings, StringUtils } from '@/Constants/Strings'
 import { concatenateUint8Arrays } from '@/Utils/ConcatenateUint8Arrays'
 import { ClassicFileReader, StreamingFileReader, StreamingFileSaver, ClassicFileSaver } from '@standardnotes/filepicker'
-import { parseAndCreateZippableFileName, parseFileName } from '@standardnotes/utils'
+import { escapeHtmlString, parseAndCreateZippableFileName, parseFileName } from '@standardnotes/utils'
 import {
   AlertService,
   ChallengeReason,
@@ -168,7 +168,7 @@ export class FilesController extends AbstractViewController<FilesControllerEvent
 
   deleteFile = async (file: FileItem) => {
     const shouldDelete = await confirmDialog({
-      text: `Are you sure you want to permanently delete "${file.name}"?`,
+      text: StringUtils.deleteFile(file.name),
       confirmButtonStyle: 'danger',
     })
     if (shouldDelete) {
@@ -440,7 +440,7 @@ export class FilesController extends AbstractViewController<FilesControllerEvent
           `This file exceeds the limits supported in this browser. To upload files greater than ${
             this.maxFileSize / BYTES_IN_ONE_MEGABYTE
           }MB, please use the desktop application or the Chrome browser.`,
-          `Cannot upload file "${file.name}"`,
+          `Cannot upload file "${escapeHtmlString(file.name)}"`,
         )
         .catch(console.error)
       return true

--- a/packages/web/src/javascripts/Controllers/FilesController.ts
+++ b/packages/web/src/javascripts/Controllers/FilesController.ts
@@ -16,7 +16,7 @@ import {
 import { Strings, StringUtils } from '@/Constants/Strings'
 import { concatenateUint8Arrays } from '@/Utils/ConcatenateUint8Arrays'
 import { ClassicFileReader, StreamingFileReader, StreamingFileSaver, ClassicFileSaver } from '@standardnotes/filepicker'
-import { escapeHtmlString, parseAndCreateZippableFileName, parseFileName } from '@standardnotes/utils'
+import { parseAndCreateZippableFileName, parseFileName } from '@standardnotes/utils'
 import {
   AlertService,
   ChallengeReason,
@@ -440,7 +440,7 @@ export class FilesController extends AbstractViewController<FilesControllerEvent
           `This file exceeds the limits supported in this browser. To upload files greater than ${
             this.maxFileSize / BYTES_IN_ONE_MEGABYTE
           }MB, please use the desktop application or the Chrome browser.`,
-          `Cannot upload file "${escapeHtmlString(file.name)}"`,
+          StringUtils.cannotUploadFile(file.name),
         )
         .catch(console.error)
       return true

--- a/packages/web/src/javascripts/Controllers/Navigation/NavigationController.ts
+++ b/packages/web/src/javascripts/Controllers/Navigation/NavigationController.ts
@@ -6,7 +6,7 @@ import {
   VaultDisplayService,
   VaultDisplayServiceEvent,
 } from '@standardnotes/ui-services'
-import { STRING_DELETE_TAG } from '@/Constants/Strings'
+import { STRING_DELETE_TAG, StringUtils } from '@/Constants/Strings'
 import { SMART_TAGS_FEATURE_NAME } from '@/Constants/Constants'
 import {
   ContentType,
@@ -604,7 +604,7 @@ export class NavigationController
     let shouldDelete = !userTriggered
     if (userTriggered) {
       shouldDelete = await confirmDialog({
-        title: `Delete tag "${tag.title}"?`,
+        title: StringUtils.deleteTag(tag.title),
         text: STRING_DELETE_TAG,
         confirmButtonStyle: 'danger',
       })


### PR DESCRIPTION
~~In the SKAlert component, both the title and the message of the dialog are being interpolated within the rest of the HTML, and then all of that HTML is set as `innerHTML` for the corresponding element. This means if the title or the message contain HTML themselves, it will be rendered within the dialog. This PR changes the implementation so that the initial template will include empty elements where the title and message will then be set using `textContent`, so that they're always displayed as strings.~~

Updated:
Because there are a few places where we intentionally use HTML within the strings for a dialog, I decided to go in a different direction and escape the HTML for notes/tags/files titles.
- Ultimately it could be better to move away from passing HTML to the alerts because there's a risk that we might forget to escape strings for user-created entities in the future again.
- I'm not entirely sure I covered all the possible cases of user-created HTML strings that should be escaped.
- When possible I updated to use functions from `StringUtils`. Having all of the strings in that one file should make it easier to spot cases where we're not escaping when needed.