### PR TITLE
fix(SNOTES-468): use injectJavascript to set safe area inset vars

### DIFF
--- a/packages/mobile/src/MobileWebAppContainer.tsx
+++ b/packages/mobile/src/MobileWebAppContainer.tsx
@@ -458,7 +458,7 @@ const MobileWebAppContents = ({ destroyAndReload }: { destroyAndReload: () => vo
             component: CustomAndroidWebView,
           } as WebViewNativeConfig,
         })}
-        webviewDebuggingEnabled={true}
+        webviewDebuggingEnabled
       />
     </View>
   )

--- a/packages/snjs/lib/Client/ReactNativeToWebEvent.ts
+++ b/packages/snjs/lib/Client/ReactNativeToWebEvent.ts
@@ -10,7 +10,6 @@ export enum ReactNativeToWebEvent {
   KeyboardWillHide = 'KeyboardWillHide',
   KeyboardDidShow = 'KeyboardDidShow',
   KeyboardDidHide = 'KeyboardDidHide',
-  UpdateSafeAreaInsets = 'UpdateSafeAreaInsets',
   ReceivedFile = 'ReceivedFile',
   ReceivedLink = 'ReceivedLink',
   ReceivedText = 'ReceivedText',

--- a/packages/ui-services/src/WebApplication/WebApplicationInterface.ts
+++ b/packages/ui-services/src/WebApplication/WebApplicationInterface.ts
@@ -21,7 +21,6 @@ export interface WebApplicationInterface extends ApplicationInterface {
     isFloatingKeyboard: boolean
   }): void
   handleMobileKeyboardDidHideEvent(): void
-  handleUpdateSafeAreaInsets(insets: { top: number; bottom: number; left: number; right: number }): void
   handleReceivedFileEvent(file: { name: string; mimeType: string; data: string }): void
   handleReceivedTextEvent(item: { text: string; title?: string }): Promise<void>
   handleReceivedLinkEvent(item: { link: string; title: string }): Promise<void>

--- a/packages/web/src/javascripts/Application/WebApplication.ts
+++ b/packages/web/src/javascripts/Application/WebApplication.ts
@@ -361,12 +361,6 @@ export class WebApplication extends SNApplication implements WebApplicationInter
     setCustomViewportHeight(100, 'vh', true)
   }
 
-  handleUpdateSafeAreaInsets(insets: { top: number; bottom: number; left: number; right: number }) {
-    for (const [key, value] of Object.entries(insets)) {
-      document.documentElement.style.setProperty(`--safe-area-inset-${key}`, `${value}px`)
-    }
-  }
-
   handleOpenFilePreviewEvent({ id }: { id: string }): void {
     const file = this.items.findItem<FileItem>(id)
     if (!file) {

--- a/packages/web/src/javascripts/NativeMobileWeb/MobileWebReceiver.ts
+++ b/packages/web/src/javascripts/NativeMobileWeb/MobileWebReceiver.ts
@@ -81,11 +81,6 @@ export class MobileWebReceiver {
       case ReactNativeToWebEvent.KeyboardDidHide:
         void this.application.handleMobileKeyboardDidHideEvent()
         break
-      case ReactNativeToWebEvent.UpdateSafeAreaInsets:
-        void this.application.handleUpdateSafeAreaInsets(
-          messageData as { top: number; left: number; bottom: number; right: number },
-        )
-        break
       case ReactNativeToWebEvent.ReceivedFile:
         void this.application.handleReceivedFileEvent(
           messageData as {


### PR DESCRIPTION
I've only been able to repro this on my production app by leaving the app open (minimized) overnight and then focusing on it again the next day. I'm not entirely sure what's going on, but I suspect that in those conditions either the effect that triggers the message to update the insets isn't fired, or the condition that checks for `didAppLaunch` before sending the message returns false.

This PR sets the CSS safe area inset vars using `injectJavascript` instead of `postMessage`. Injecting JS is actually the recommended way to pass information from RN to Web per the react-native-webview docs, and there's an example in the docs where this is used to update the background color of the webview https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#the-injectjavascript-method. This will run on every render, and that way we ensure that the correct inset paddings are always being set.