### PR TITLE
fix linked item issues in Super editor

### DIFF
--- a/packages/web/src/javascripts/Components/LinkedItems/LinkedItemBubble.tsx
+++ b/packages/web/src/javascripts/Components/LinkedItems/LinkedItemBubble.tsx
@@ -56,8 +56,10 @@ const LinkedItemBubble = ({
     setShowUnlinkButton(true)
   }
 
-  const onBlur = () => {
-    setShowUnlinkButton(false)
+  const onBlur: React.FocusEventHandler<HTMLButtonElement | HTMLAnchorElement> = (event) => {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      setShowUnlinkButton(false)
+    }
     setWasClicked(false)
   }
 
@@ -131,8 +133,10 @@ const LinkedItemBubble = ({
           <button
             ref={(el) => (unlinkButtonRef.current = el as HTMLElement)}
             role="button"
-            className="-mr-1 ml-2 inline-flex cursor-pointer border-0 bg-transparent p-0 h-[1.15em] align-middle"
-            onClick={onUnlinkClick}
+            className="-mr-1 ml-2 inline-flex h-[1.15em] cursor-pointer border-0 bg-transparent p-0 align-middle"
+            onClick={(event) => {
+              onUnlinkClick(event)
+            }}
           >
             <Icon type="close" className="text-neutral hover:text-info" size="small" />
           </button>

--- a/packages/web/src/javascripts/Components/SuperEditor/Plugins/ItemBubblePlugin/Nodes/BubbleComponent.tsx
+++ b/packages/web/src/javascripts/Components/SuperEditor/Plugins/ItemBubblePlugin/Nodes/BubbleComponent.tsx
@@ -30,15 +30,11 @@ export function BubbleComponent({ itemUuid, node }: BubbleComponentProps) {
     [toggleAppPane, linkingController],
   )
 
-  const unlinkPressed = useCallback(
-    async (itemToUnlink: LinkableItem) => {
-      linkingController.unlinkItemFromSelectedItem(itemToUnlink).catch(console.error)
-      editor.update(() => {
-        node.remove()
-      })
-    },
-    [linkingController, node, editor],
-  )
+  const unlinkPressed = useCallback(async () => {
+    editor.update(() => {
+      node.remove()
+    })
+  }, [linkingController, node, editor])
 
   if (!item) {
     return <div>Unable to find item {itemUuid}</div>

--- a/packages/web/src/javascripts/Components/SuperEditor/Plugins/ItemSelectionPlugin/ItemSelectionItemComponent.tsx
+++ b/packages/web/src/javascripts/Components/SuperEditor/Plugins/ItemSelectionPlugin/ItemSelectionItemComponent.tsx
@@ -32,13 +32,7 @@ export function ItemSelectionItemComponent({ index, isSelected, onClick, onMouse
       onClick={onClick}
     >
       {option.item && <LinkedItemMeta item={option.item} searchQuery={searchQuery} />}
-      {!option.item && (
-        <LinkedItemSearchResultsAddTagOption
-          searchQuery={searchQuery}
-          onClickCallback={onClick}
-          isFocused={isSelected}
-        />
-      )}
+      {!option.item && <LinkedItemSearchResultsAddTagOption searchQuery={searchQuery} isFocused={isSelected} />}
     </li>
   )
 }


### PR DESCRIPTION
- Fixes linked items being embedded twice when clicking on them in the typeahead instead of pressing Enter
- Fixes the Remove button not doing anything when clicked for embedded linked items