### PR TITLE
fix: Fixes Google Keep comverter failing if date format in heading is…

### DIFF
--- a/packages/ui-services/src/Import/GoogleKeepConverter/GoogleKeepConverter.ts
+++ b/packages/ui-services/src/Import/GoogleKeepConverter/GoogleKeepConverter.ts
@@ -78,7 +78,8 @@ export class GoogleKeepConverter implements Converter {
     rootElement.innerHTML = data
 
     const headingElement = rootElement.getElementsByClassName('heading')[0]
-    const date = new Date(headingElement?.textContent || '')
+    const parsedDate = new Date(headingElement?.textContent || '')
+    const date = parsedDate instanceof Date && !isNaN(parsedDate.getTime()) ? parsedDate : new Date()
     headingElement?.remove()
 
     const contentElement = rootElement.getElementsByClassName('content')[0]


### PR DESCRIPTION
… invalid

The date in the heading for HTML notes imported from Google Keep using Google Takeout seems to use different formats likely depending on the user's locale. Since we don't know which formats are possible, we can at least check that we get a valid date object when attempting to parse it, and if not, default to today's date to prevent the tool from failing altogether.