### PR TITLE
feat: Improves Add Tag dropdown UI

### DIFF
--- a/packages/web/src/javascripts/Components/NotesOptions/AddTagOption.tsx
+++ b/packages/web/src/javascripts/Components/NotesOptions/AddTagOption.tsx
@@ -92,14 +92,19 @@ const AddTagOption: FunctionComponent<Props> = ({
                   className={'ml-0.5 mr-1.5 h-7 w-7 text-2xl text-neutral lg:h-6 lg:w-6 lg:text-lg'}
                 />
               )}
-              <span
-                className={classNames(
-                  'overflow-hidden overflow-ellipsis whitespace-nowrap',
-                  isTagLinkedToSelectedItems(tag) ? 'font-bold' : '',
-                )}
-              >
-                {getTitleForLinkedTag(tag, application)?.longTitle}
-              </span>
+              <div>
+                <p className="overflow-hidden overflow-ellipsis whitespace-nowrap text-passive-2">
+                  {getTitleForLinkedTag(tag, application)?.titlePrefix}
+                </p>
+                <p
+                  className={classNames(
+                    'overflow-hidden overflow-ellipsis whitespace-nowrap',
+                    isTagLinkedToSelectedItems(tag) ? 'font-bold' : '',
+                  )}
+                >
+                  {tag.title}
+                </p>
+              </div>
             </MenuItem>
           ))}
         </Menu>


### PR DESCRIPTION
With the current UI, the tag's long title including all its parent chain is shown in one line, which means if the chain is long the actual tag title isn't visible. It also makes it hard to understand the sorting of the tags. This moves the tag prefix to a different line and with a different format to make which is the actual tag clearer.