### PR TITLE
Fix the default language style for newly created code blocks

### DIFF
--- a/packages/web/src/javascripts/Components/SuperEditor/Plugins/Blocks/Code.tsx
+++ b/packages/web/src/javascripts/Components/SuperEditor/Plugins/Blocks/Code.tsx
@@ -13,10 +13,10 @@ export const CodeBlock = {
       const selection = $getSelection()
       if ($isRangeSelection(selection)) {
         if (selection.isCollapsed()) {
-          $setBlocksType(selection, () => $createCodeNode())
+          $setBlocksType(selection, () => $createCodeNode('plain'))
         } else {
           const textContent = selection.getTextContent()
-          const codeNode = $createCodeNode()
+          const codeNode = $createCodeNode('plain')
           selection.insertNodes([codeNode])
           selection.insertRawText(textContent)
         }


### PR DESCRIPTION
It seems that most code in `CodeOptions.tsx` that tries to set default language as 'empty' provides little help, and somehow always fallback to JS (https://github.com/facebook/lexical/blob/5dd93a7c8b4b23d2b00a547c2d860cb17aed1e52/packages/lexical-code-core/src/CodeNode.ts#L52).

I marked this as a "fix" is because line 18 suggests that the plain text type was needed at the very beginning. 