### PR TITLE
chore: ttag for subscription-related UI

### DIFF
--- a/packages/web/src/javascripts/Components/NoSubscriptionBanner/NoSubscriptionBanner.tsx
+++ b/packages/web/src/javascripts/Components/NoSubscriptionBanner/NoSubscriptionBanner.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@standardnotes/utils'
 import Button from '../Button/Button'
 import Icon from '../Icon/Icon'
 import { PremiumFeatureIconClass, PremiumFeatureIconName } from '../Icon/PremiumFeatureIcon'
+import { c } from 'ttag'
 
 const NoSubscriptionBanner = ({
   application,
@@ -31,7 +32,7 @@ const NoSubscriptionBanner = ({
       </div>
       <p className="col-start-1 col-end-3 m-0 mt-1 text-sm">{message}</p>
       <Button primary small className="col-start-1 col-end-3 mt-3 justify-self-start uppercase" onClick={onClick}>
-        Upgrade Features
+        {c('Action').t`Upgrade Features`}
       </Button>
     </div>
   )

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/NoProSubscription.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/NoProSubscription.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, ReactNode, useState } from 'react'
 import { LinkButton, Text } from '@/Components/Preferences/PreferencesComponents/Content'
 import Button from '@/Components/Button/Button'
 import { WebApplication } from '@/Application/WebApplication'
+import { c } from 'ttag'
 
 type Props = {
   application: WebApplication
@@ -13,7 +14,7 @@ const NoProSubscription: FunctionComponent<Props> = ({ application, text }) => {
   const [purchaseFlowError, setPurchaseFlowError] = useState<string | undefined>(undefined)
 
   const onPurchaseClick = async () => {
-    const errorMessage = 'There was an error when attempting to redirect you to the subscription page.'
+    const errorMessage = c('Error').t`There was an error when attempting to redirect you to the subscription page.`
     setIsLoadingPurchaseFlow(true)
     try {
       if (application.isNativeIOS()) {
@@ -33,15 +34,19 @@ const NoProSubscription: FunctionComponent<Props> = ({ application, text }) => {
   return (
     <>
       <Text>{text}</Text>
-      {isLoadingPurchaseFlow && <Text>Redirecting you to the subscription page...</Text>}
+      {isLoadingPurchaseFlow && <Text>{c('Info').t`Redirecting you to the subscription page...`}</Text>}
       {purchaseFlowError && <Text className="text-danger">{purchaseFlowError}</Text>}
 
       <div className="flex">
         {!application.hideOutboundSubscriptionLinks && (
-          <LinkButton className="mr-3 mt-3 min-w-20" label="Learn More" link={window.plansUrl as string} />
+          <LinkButton
+            className="mr-3 mt-3 min-w-20"
+            label={c('Action').t`Learn More`}
+            link={window.plansUrl as string}
+          />
         )}
         {application.hasAccount() && (
-          <Button className="mt-3 min-w-20" primary label="Upgrade" onClick={onPurchaseClick} />
+          <Button className="mt-3 min-w-20" primary label={c('Action').t`Upgrade`} onClick={onPurchaseClick} />
         )}
       </div>
     </>

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/NoSubscription.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/NoSubscription.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useState } from 'react'
 import { LinkButton, Text } from '@/Components/Preferences/PreferencesComponents/Content'
 import Button from '@/Components/Button/Button'
 import { WebApplication } from '@/Application/WebApplication'
+import { c } from 'ttag'
 
 type Props = {
   application: WebApplication
@@ -12,7 +13,7 @@ const NoSubscription: FunctionComponent<Props> = ({ application }) => {
   const [purchaseFlowError, setPurchaseFlowError] = useState<string | undefined>(undefined)
 
   const onPurchaseClick = async () => {
-    const errorMessage = 'There was an error when attempting to redirect you to the subscription page.'
+    const errorMessage = c('Error').t`There was an error when attempting to redirect you to the subscription page.`
     setIsLoadingPurchaseFlow(true)
     try {
       if (application.isNativeIOS()) {
@@ -29,15 +30,19 @@ const NoSubscription: FunctionComponent<Props> = ({ application }) => {
 
   return (
     <>
-      <Text>You don't have a Standard Notes subscription yet.</Text>
-      {isLoadingPurchaseFlow && <Text>Redirecting you to the subscription page...</Text>}
+      <Text>{c('Info').t`You don't have a Standard Notes subscription yet.`}</Text>
+      {isLoadingPurchaseFlow && <Text>{c('Info').t`Redirecting you to the subscription page...`}</Text>}
       {purchaseFlowError && <Text className="text-danger">{purchaseFlowError}</Text>}
       <div className="flex">
         {!application.hideOutboundSubscriptionLinks && (
-          <LinkButton className="mr-3 mt-3 min-w-20" label="Learn More" link={window.plansUrl as string} />
+          <LinkButton
+            className="mr-3 mt-3 min-w-20"
+            label={c('Action').t`Learn More`}
+            link={window.plansUrl as string}
+          />
         )}
         {application.hasAccount() && (
-          <Button className="mt-3 min-w-20" primary label="Subscribe" onClick={onPurchaseClick} />
+          <Button className="mt-3 min-w-20" primary label={c('Action').t`Subscribe`} onClick={onPurchaseClick} />
         )}
       </div>
     </>

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/Subscription.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/Subscription.tsx
@@ -1,4 +1,5 @@
 import { Title } from '@/Components/Preferences/PreferencesComponents/Content'
+import { c } from 'ttag'
 import SubscriptionInformation from './SubscriptionInformation'
 import NoSubscription from './NoSubscription'
 import { observer } from 'mobx-react-lite'
@@ -32,7 +33,7 @@ const Subscription: FunctionComponent = () => {
       <PreferencesSegment>
         <div className="flex flex-row items-center">
           <div className="flex flex-grow flex-col">
-            <Title>Subscription</Title>
+            <Title>{c('Title').t`Subscription`}</Title>
             {onlineSubscription ? <SubscriptionInformation /> : <NoSubscription application={application} />}
           </div>
         </div>

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/SubscriptionInformation.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/SubscriptionInformation.tsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react-lite'
 import Button from '@/Components/Button/Button'
 import SubscriptionStatusText from './SubscriptionStatusText'
 import { useApplication } from '@/Components/ApplicationProvider'
+import { c } from 'ttag'
 
 const SubscriptionInformation = () => {
   const application = useApplication()
@@ -15,7 +16,11 @@ const SubscriptionInformation = () => {
     <>
       <SubscriptionStatusText />
       {!isSharedSubscription && (
-        <Button className="mr-3 mt-3 min-w-20" label="Manage subscription" onClick={manageSubscription} />
+        <Button
+          className="mr-3 mt-3 min-w-20"
+          label={c('Action').t`Manage subscription`}
+          onClick={manageSubscription}
+        />
       )}
     </>
   )

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/SubscriptionStatusText.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/Subscription/SubscriptionStatusText.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite'
 import { Text } from '@/Components/Preferences/PreferencesComponents/Content'
 import { useApplication } from '@/Components/ApplicationProvider'
+import { c } from 'ttag'
 
 const SubscriptionStatusText = () => {
   const application = useApplication()
@@ -18,25 +19,28 @@ const SubscriptionStatusText = () => {
     <>
       <br />
       <br />
-      This subscription has been shared with you and can only be managed by the owner.
+      {c('Info').t`This subscription has been shared with you and can only be managed by the owner.`}
     </>
   ) : null
 
+  const planName = `Standard Notes${userSubscriptionName ? ` ${userSubscriptionName}` : ''}`
+  const planNameSpan = <span className="font-bold">{planName}</span>
+  const dateSpan = <span className="font-bold">{expirationDateString}</span>
+
   if (isUserSubscriptionCanceled) {
+    if (isUserSubscriptionExpired) {
+      return (
+        <Text className="mt-1">
+          {c('Info')
+            .jt`Your ${planNameSpan} subscription has been canceled and expired on ${dateSpan}. You may resubscribe below if you wish.`}
+          {sharedMessage}
+        </Text>
+      )
+    }
     return (
       <Text className="mt-1">
-        Your{' '}
-        <span className="font-bold">
-          Standard Notes{userSubscriptionName ? ' ' : ''}
-          {userSubscriptionName}
-        </span>{' '}
-        subscription has been canceled{' '}
-        {isUserSubscriptionExpired ? (
-          <span className="font-bold">and expired on {expirationDateString}</span>
-        ) : (
-          <span className="font-bold">but will remain valid until {expirationDateString}</span>
-        )}
-        . You may resubscribe below if you wish.
+        {c('Info')
+          .jt`Your ${planNameSpan} subscription has been canceled but will remain valid until ${dateSpan}. You may resubscribe below if you wish.`}
         {sharedMessage}
       </Text>
     )
@@ -45,13 +49,7 @@ const SubscriptionStatusText = () => {
   if (isUserSubscriptionExpired) {
     return (
       <Text className="mt-1">
-        Your{' '}
-        <span className="font-bold">
-          Standard Notes{userSubscriptionName ? ' ' : ''}
-          {userSubscriptionName}
-        </span>{' '}
-        subscription <span className="font-bold">expired on {expirationDateString}</span>. You may resubscribe below if
-        you wish.
+        {c('Info').jt`Your ${planNameSpan} subscription expired on ${dateSpan}. You may resubscribe below if you wish.`}
         {sharedMessage}
       </Text>
     )
@@ -59,12 +57,8 @@ const SubscriptionStatusText = () => {
 
   return (
     <Text className="mt-1">
-      Your{' '}
-      <span className="font-bold">
-        Standard Notes{userSubscriptionName ? ' ' : ''}
-        {userSubscriptionName}
-      </span>{' '}
-      subscription will be <span className="font-bold">renewed on {expirationDateString}</span>.{sharedMessage}
+      {c('Info').jt`Your ${planNameSpan} subscription will be renewed on ${dateSpan}.`}
+      {sharedMessage}
     </Text>
   )
 }

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/InvitationsList.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/InvitationsList.tsx
@@ -7,6 +7,7 @@ import { SubscriptionController } from '@/Controllers/Subscription/SubscriptionC
 import Button from '@/Components/Button/Button'
 import { WebApplication } from '@/Application/WebApplication'
 import HorizontalSeparator from '@/Components/Shared/HorizontalSeparator'
+import { c } from 'ttag'
 
 type Props = {
   subscriptionState: SubscriptionController
@@ -24,15 +25,15 @@ const InvitationsList = ({ subscriptionState, application }: Props) => {
 
   const handleCancel = async (invitationUuid: string) => {
     if (lockContinue) {
-      application.alerts.alert('Cancelation already in progress.').catch(console.error)
+      application.alerts.alert(c('Info').t`Cancelation already in progress.`).catch(console.error)
 
       return
     }
 
     const confirmed = await application.alerts.confirm(
-      'All uploaded files of this user will be removed. This action cannot be undone.',
-      'Are you sure you want to cancel this invitation?',
-      'Cancel Invitation',
+      c('Info').t`All uploaded files of this user will be removed. This action cannot be undone.`,
+      c('Title').t`Are you sure you want to cancel this invitation?`,
+      c('Action').t`Cancel Invitation`,
       ButtonType.Danger,
     )
     if (!confirmed) {
@@ -47,25 +48,29 @@ const InvitationsList = ({ subscriptionState, application }: Props) => {
 
     if (!success) {
       application.alerts
-        .alert('Could not cancel invitation. Please try again or contact support if the issue persists.')
+        .alert(c('Error').t`Could not cancel invitation. Please try again or contact support if the issue persists.`)
         .catch(console.error)
     }
   }
 
   if (usedInvitationsCount === 0) {
-    return <Text className="mb-3 mt-1">Make your first subscription invite below.</Text>
+    return <Text className="mb-3 mt-1">{c('Info').t`Make your first subscription invite below.`}</Text>
   }
 
   return (
     <div>
-      <SubtitleLight className="mb-2 text-info">Active Invites</SubtitleLight>
+      <SubtitleLight className="mb-2 text-info">{c('Subtitle').t`Active Invites`}</SubtitleLight>
       {activeSubscriptions?.map((invitation) => (
         <div key={invitation.uuid} className="mb-4 mt-1">
           <Text>
             {invitation.inviteeIdentifier} <span className="text-info">({invitation.status})</span>
           </Text>
           {invitation.status !== InvitationStatus.Canceled && (
-            <Button className="mt-2 min-w-20" label="Cancel" onClick={() => handleCancel(invitation.uuid)} />
+            <Button
+              className="mt-2 min-w-20"
+              label={c('Action').t`Cancel`}
+              onClick={() => handleCancel(invitation.uuid)}
+            />
           )}
         </div>
       ))}

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/Invite/Invite.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/Invite/Invite.tsx
@@ -7,12 +7,7 @@ import { SubscriptionController } from '@/Controllers/Subscription/SubscriptionC
 import InviteForm from './InviteForm'
 import InviteSuccess from './InviteSuccess'
 import Modal, { ModalAction } from '@/Components/Modal/Modal'
-
-enum SubmitButtonTitles {
-  Default = 'Invite',
-  Sending = 'Sending...',
-  Finish = 'Finish',
-}
+import { c } from 'ttag'
 
 enum Steps {
   InitialStep,
@@ -26,7 +21,7 @@ type Props = {
 }
 
 const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscriptionState }) => {
-  const [submitButtonTitle, setSubmitButtonTitle] = useState(SubmitButtonTitles.Default)
+  const [submitButtonTitle, setSubmitButtonTitle] = useState(() => c('Action').t`Invite`)
   const [inviteeEmail, setInviteeEmail] = useState('')
   const [isContinuing, setIsContinuing] = useState(false)
   const [lockContinue, setLockContinue] = useState(false)
@@ -35,7 +30,7 @@ const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscrip
   const validateInviteeEmail = useCallback(async () => {
     if (!isEmailValid(inviteeEmail)) {
       application.alerts
-        .alert('The email you entered has an invalid format. Please review your input and try again.')
+        .alert(c('Error').t`The email you entered has an invalid format. Please review your input and try again.`)
         .catch(console.error)
 
       return false
@@ -46,14 +41,14 @@ const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscrip
 
   const handleDialogClose = useCallback(() => {
     if (lockContinue) {
-      application.alerts.alert('Cannot close window until pending tasks are complete.').catch(console.error)
+      application.alerts.alert(c('Info').t`Cannot close window until pending tasks are complete.`).catch(console.error)
     } else {
       onCloseDialog()
     }
   }, [application.alerts, lockContinue, onCloseDialog])
 
   const resetProgressState = () => {
-    setSubmitButtonTitle(SubmitButtonTitles.Default)
+    setSubmitButtonTitle(c('Action').t`Invite`)
     setIsContinuing(false)
   }
 
@@ -79,7 +74,7 @@ const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscrip
     }
 
     setIsContinuing(true)
-    setSubmitButtonTitle(SubmitButtonTitles.Sending)
+    setSubmitButtonTitle(c('Action').t`Sending...`)
 
     const valid = await validateInviteeEmail()
 
@@ -92,7 +87,10 @@ const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscrip
     const success = await processInvite()
     if (!success) {
       application.alerts
-        .alert('An error occurred while sending the invite. Please try again or contact support if the issue persists.')
+        .alert(
+          c('Error')
+            .t`An error occurred while sending the invite. Please try again or contact support if the issue persists.`,
+        )
         .catch(console.error)
 
       resetProgressState()
@@ -101,7 +99,7 @@ const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscrip
     }
 
     setIsContinuing(false)
-    setSubmitButtonTitle(SubmitButtonTitles.Finish)
+    setSubmitButtonTitle(c('Action').t`Finish`)
     setCurrentStep(Steps.FinishStep)
   }, [
     application.alerts,
@@ -123,7 +121,7 @@ const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscrip
         disabled: lockContinue,
       },
       {
-        label: 'Cancel',
+        label: c('Action').t`Cancel`,
         onClick: handleDialogClose,
         type: 'cancel',
         mobileSlot: 'left',
@@ -134,7 +132,7 @@ const Invite: FunctionComponent<Props> = ({ onCloseDialog, application, subscrip
   )
 
   return (
-    <Modal title="Share Your Subscription" close={handleDialogClose} actions={modalActions}>
+    <Modal title={c('Title').t`Share Your Subscription`} close={handleDialogClose} actions={modalActions}>
       <div className="px-4.5 py-4">
         {currentStep === Steps.InitialStep && <InviteForm setInviteeEmail={setInviteeEmail} />}
         {currentStep === Steps.FinishStep && <InviteSuccess />}

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/Invite/InviteForm.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/Invite/InviteForm.tsx
@@ -1,6 +1,7 @@
 import { Dispatch, FunctionComponent, SetStateAction } from 'react'
 
 import DecoratedInput from '@/Components/Input/DecoratedInput'
+import { c } from 'ttag'
 
 type Props = {
   setInviteeEmail: Dispatch<SetStateAction<string>>
@@ -11,7 +12,7 @@ const InviteForm: FunctionComponent<Props> = ({ setInviteeEmail }) => {
     <div className="flex w-full flex-col">
       <div className="mb-3">
         <label className="mb-1 block font-bold" htmlFor="invite-email-input">
-          Invitee Email
+          {c('Label').t`Invitee Email`}
         </label>
 
         <DecoratedInput
@@ -24,9 +25,9 @@ const InviteForm: FunctionComponent<Props> = ({ setInviteeEmail }) => {
         />
 
         <p className="mt-4">
-          <span className="font-bold">Note: </span>
-          The invitee must have an existing account with Standard Notes. If they do not have an account yet, instruct
-          them to make an account first.
+          <span className="font-bold">{c('Label').t`Note:`} </span>
+          {c('Info')
+            .t`The invitee must have an existing account with Standard Notes. If they do not have an account yet, instruct them to make an account first.`}
         </p>
       </div>
     </div>

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/Invite/InviteSuccess.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/Invite/InviteSuccess.tsx
@@ -1,12 +1,13 @@
 import { Title } from '@/Components/Preferences/PreferencesComponents/Content'
 import { FunctionComponent } from 'react'
+import { c } from 'ttag'
 
 const InviteSuccess: FunctionComponent = () => {
   return (
     <div>
-      <Title className="mb-2">Invite processed successfully.</Title>
+      <Title className="mb-2">{c('Title').t`Invite processed successfully.`}</Title>
       <div className={'mt-2'}>
-        If an account is found with that email, they will receive an email with your invitation.
+        {c('Info').t`If an account is found with that email, they will receive an email with your invitation.`}
       </div>
     </div>
   )

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/SharingStatusText.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/SharingStatusText.tsx
@@ -1,6 +1,7 @@
 import { SubscriptionController } from '@/Controllers/Subscription/SubscriptionController'
 import { observer } from 'mobx-react-lite'
 import { Text } from '@/Components/Preferences/PreferencesComponents/Content'
+import { c } from 'ttag'
 
 type Props = { subscriptionState: SubscriptionController }
 
@@ -9,8 +10,9 @@ const SharingStatusText = ({ subscriptionState }: Props) => {
 
   return (
     <Text className="mt-1">
-      You've used <span className="font-bold">{usedInvitationsCount}</span> out of {allowedInvitationsCount}{' '}
-      subscription invites.
+      {c('Info').jt`You've used ${(
+        <span className="font-bold">{usedInvitationsCount}</span>
+      )} out of ${allowedInvitationsCount} subscription invites.`}
     </Text>
   )
 }

--- a/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/SubscriptionSharing.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/Account/SubscriptionSharing/SubscriptionSharing.tsx
@@ -13,6 +13,7 @@ import Invite from './Invite/Invite'
 import Button from '@/Components/Button/Button'
 import SharingStatusText from './SharingStatusText'
 import ModalOverlay from '@/Components/Modal/ModalOverlay'
+import { c } from 'ttag'
 
 type Props = {
   application: WebApplication
@@ -37,14 +38,18 @@ const SubscriptionSharing: FunctionComponent<Props> = ({ application }: Props) =
       <PreferencesSegment>
         <div className="flex flex-row items-center">
           <div className="flex flex-grow flex-col">
-            <Title className="mb-2">Subscription sharing</Title>
+            <Title className="mb-2">{c('Title').t`Subscription sharing`}</Title>
             {isSubscriptionSharingFeatureAvailable ? (
               <div>
                 <SharingStatusText subscriptionState={subscriptionState} />
                 <HorizontalSeparator classes="my-4" />
                 <InvitationsList subscriptionState={subscriptionState} application={application} />
                 {!subscriptionState.allInvitationsUsed && (
-                  <Button className="min-w-20" label="Invite" onClick={() => setIsInviteDialogOpen(true)} />
+                  <Button
+                    className="min-w-20"
+                    label={c('Action').t`Invite`}
+                    onClick={() => setIsInviteDialogOpen(true)}
+                  />
                 )}
                 <ModalOverlay isOpen={isInviteDialogOpen} close={closeInviteDialog}>
                   <Invite
@@ -59,8 +64,9 @@ const SubscriptionSharing: FunctionComponent<Props> = ({ application }: Props) =
                 application={application}
                 text={
                   <span>
-                    Subscription sharing is available only on the <span className="font-bold">Professional</span> plan.
-                    Please upgrade in order to share your subscription.
+                    {c('Info').jt`Subscription sharing is available only on the ${(
+                      <span className="font-bold">{c('Info').t`Professional`}</span>
+                    )} plan. Please upgrade in order to share your subscription.`}
                   </span>
                 }
               />

--- a/packages/web/src/javascripts/Components/Preferences/Panes/General/Offline/OfflineSubscription.tsx
+++ b/packages/web/src/javascripts/Components/Preferences/Panes/General/Offline/OfflineSubscription.tsx
@@ -6,6 +6,7 @@ import { WebApplication } from '@/Application/WebApplication'
 import { observer } from 'mobx-react-lite'
 import { STRING_REMOVE_OFFLINE_KEY_CONFIRMATION } from '@/Constants/Strings'
 import { ButtonType, ClientDisplayableError } from '@standardnotes/snjs'
+import { c } from 'ttag'
 
 type Props = {
   application: WebApplication
@@ -40,7 +41,7 @@ const OfflineSubscription: FunctionComponent<Props> = ({ application, onSuccess 
 
     if (homeServerEnabled) {
       if (!homeServerIsRunning) {
-        await application.alerts.alert('Please start your home server before activating offline features.')
+        await application.alerts.alert(c('Error').t`Please start your home server before activating offline features.`)
 
         return
       }
@@ -97,10 +98,10 @@ const OfflineSubscription: FunctionComponent<Props> = ({ application, onSuccess 
     application.alerts
       .confirm(
         STRING_REMOVE_OFFLINE_KEY_CONFIRMATION,
-        'Remove offline key?',
-        'Remove Offline Key',
+        c('Title').t`Remove offline key?`,
+        c('Action').t`Remove Offline Key`,
         ButtonType.Danger,
-        'Cancel',
+        c('Action').t`Cancel`,
       )
       .then(async (shouldRemove: boolean) => {
         if (shouldRemove) {
@@ -121,14 +122,18 @@ const OfflineSubscription: FunctionComponent<Props> = ({ application, onSuccess 
       <div className="flex items-center justify-between">
         <div className="mt-3 flex w-full flex-col">
           <div className="flex flex-row items-center justify-between">
-            <Subtitle>{!hasUserPreviouslyStoredCode && 'Activate'} Offline Subscription</Subtitle>
+            <Subtitle>
+              {hasUserPreviouslyStoredCode
+                ? c('Subtitle').t`Offline Subscription`
+                : c('Subtitle').t`Activate Offline Subscription`}
+            </Subtitle>
             <a
               href="https://standardnotes.com/help/59/can-i-use-standard-notes-totally-offline"
               target="_blank"
               rel="noreferrer"
               className="text-info"
             >
-              Learn more
+              {c('Action').t`Learn more`}
             </a>
           </div>
           <form onSubmit={handleSubscriptionCodeSubmit}>
@@ -136,7 +141,7 @@ const OfflineSubscription: FunctionComponent<Props> = ({ application, onSuccess 
               {!hasUserPreviouslyStoredCode && (
                 <DecoratedInput
                   onChange={(code) => setActivationCode(code)}
-                  placeholder={'Offline Subscription Code'}
+                  placeholder={c('Label').t`Offline Subscription Code`}
                   value={activationCode}
                   disabled={isSuccessfullyActivated}
                   className={{ container: 'mb-3' }}
@@ -145,14 +150,15 @@ const OfflineSubscription: FunctionComponent<Props> = ({ application, onSuccess 
             </div>
             {(isSuccessfullyActivated || isSuccessfullyRemoved) && (
               <div className={'info mb-3 mt-3'}>
-                Your offline subscription code has been successfully {isSuccessfullyActivated ? 'activated' : 'removed'}
-                .
+                {isSuccessfullyActivated
+                  ? c('Info').t`Your offline subscription code has been successfully activated.`
+                  : c('Info').t`Your offline subscription code has been successfully removed.`}
               </div>
             )}
             {hasUserPreviouslyStoredCode && (
               <Button
                 colorStyle="danger"
-                label="Remove offline key"
+                label={c('Action').t`Remove offline key`}
                 onClick={() => {
                   handleRemoveClick().catch(console.error)
                 }}
@@ -161,7 +167,7 @@ const OfflineSubscription: FunctionComponent<Props> = ({ application, onSuccess 
             {!hasUserPreviouslyStoredCode && !isSuccessfullyActivated && (
               <Button
                 hidden={activationCode.length === 0}
-                label={'Submit'}
+                label={c('Action').t`Submit`}
                 primary
                 disabled={activationCode === ''}
                 onClick={(event) => handleSubscriptionCodeSubmit(event)}


### PR DESCRIPTION
Continues the ttag migration started in #2987 and #3007. Wraps all user-facing strings in the subscription areas:

- Account › Subscription pane (status text, manage/subscribe buttons)
- Account › Subscription Sharing pane (invites list, invite modal flow)
- General › Offline Subscription (activation/removal flow)
- NoSubscriptionBanner (premium upgrade prompt)
- NoProSubscription (shared upgrade CTA)

No functional changes, strings still render in English until translation catalogs are added.