### PR TITLE
ci: pin third-party actions to full commit SHAs

### DIFF
--- a/.github/workflows/snjs.pr.yml
+++ b/.github/workflows/snjs.pr.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run E2E test suite
-        uses: convictional/trigger-workflow-and-wait@master
+        uses: convictional/trigger-workflow-and-wait@224756e4cc7fa0b711a281193496319f816cd880 # master
         with:
           owner: standardnotes
           repo: server
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run E2E vaults test suite
-        uses: convictional/trigger-workflow-and-wait@master
+        uses: convictional/trigger-workflow-and-wait@224756e4cc7fa0b711a281193496319f816cd880 # master
         with:
           owner: standardnotes
           repo: server

--- a/.github/workflows/web.release.prod.yml
+++ b/.github/workflows/web.release.prod.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Deploy static site to S3 bucket
         run: aws s3 sync packages/web/dist/ s3://app.standardnotes.com --delete
       - name: Invalidate CloudFront Cache
-        uses: chetan/invalidate-cloudfront-action@master
+        uses: chetan/invalidate-cloudfront-action@fce6f6f546fae2e9fe55f3bd1411063a908f2557 # master
         env:
           DISTRIBUTION: ${{ secrets.WEBAPP_CLOUDFRONT_COM_DISTRIBUTION_ID }}
           PATHS: '/*'
@@ -46,6 +46,6 @@ jobs:
 
     steps:
     - name: Run Discord Webhook
-      uses: johnnyhuy/actions-discord-git-webhook@main
+      uses: johnnyhuy/actions-discord-git-webhook@344d3543a4d21067013d88ab8ee47ad498d8bb98 # main
       with:
         webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
### What
Pin three third-party actions currently on `@master`/`@main` to their commit SHA:

| Action | Where | Credentials |
|---|---|---|
| `chetan/invalidate-cloudfront-action@master` | `web.release.prod.yml` (deploy) | production **AWS access key + secret** |
| `convictional/trigger-workflow-and-wait@master` | `snjs.pr.yml` (e2e-base, e2e-vaults) | `CI_PAT_TOKEN` (PAT) |
| `johnnyhuy/actions-discord-git-webhook@main` | `web.release.prod.yml` (notify) | `DISCORD_WEBHOOK_URL` |

### Why
`@master`/`@main` are moving refs. The `invalidate-cloudfront-action` step is handed the **production AWS
access key + secret**; a moved tag there (compromise or an accidental change) would run unreviewed code
with those keys — the class behind the 2025 `tj-actions/changed-files` incident, here allowing S3/CloudFront
takeover. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (each SHA is the current tip). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the credential exposure, and the pinned SHAs myself.</sub>
