### PR TITLE
fix: preferences sidebar unclickable when opened in focus mode

### DIFF
--- a/packages/desktop/app/stylesheets/renderer.css
+++ b/packages/desktop/app/stylesheets/renderer.css
@@ -87,6 +87,10 @@
   -webkit-app-region: no-drag;
 }
 
+.mac-desktop.focus-mode #editor-column {
+  -webkit-app-region: no-drag;
+}
+
 .mac-desktop [data-dialog-portal]:has([data-dialog])::after {
   content: '';
   position: absolute;


### PR DESCRIPTION
In focus mode at viewport widths ≥ 1200px, #editor-column padding grows to 20% and is marked -webkit-app-region: drag. macOS hit-tests drag regions above the web layer, so this padding band swallows mouse events for the preferences sidebar rendered beneath it — the menu items are plain divs, not button/input elements exempted globally in renderer.css.

Fixed by marking #editor-column as no-drag in focus mode. Window dragging is unaffected since the #editor-column:before pseudo-element already provides a dedicated drag area.

Tested with focus mode on/off across viewport widths (~900, ~1100, ~1300, ~1600px), confirming preferences sidebar works in all cases and window dragging still works via the top strip.

Fixes standardnotes/forum#4140